### PR TITLE
Integrate toolchain image resolution into klausctl start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Integrate toolchain image resolution into `klausctl start`: prebuilt toolchain images (e.g., `giantswarm/klaus-go:1.0.0`) are used directly, non-prebuilt toolchain configs trigger a composite image build, and the resolved image is tracked in instance state and displayed in `klausctl status`. ([#19](https://github.com/giantswarm/klausctl/issues/19))
 - Add composite image builder for toolchains (`pkg/devenv/`): generates a Dockerfile layering Klaus agent capabilities on a language base image, computes deterministic image tags, and orchestrates builds with local cache fast-path. ([#17](https://github.com/giantswarm/klausctl/issues/17))
 - Add toolchain configuration support for specifying a base language image, prebuilt flag, and extra apt packages. ([#16](https://github.com/giantswarm/klausctl/issues/16))
 - Add `BuildImage` and `ImageExists` methods to the `Runtime` interface for composite image building. ([#18](https://github.com/giantswarm/klausctl/issues/18))

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -1,0 +1,242 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/runtime"
+)
+
+// startMockRuntime implements runtime.Runtime for testing resolveImage.
+type startMockRuntime struct {
+	name           string
+	imageExists    bool
+	imageExistsErr error
+	buildCalled    bool
+	buildOpts      runtime.BuildOptions
+	buildErr       error
+}
+
+var _ runtime.Runtime = (*startMockRuntime)(nil)
+
+func (m *startMockRuntime) Name() string { return m.name }
+
+func (m *startMockRuntime) ImageExists(_ context.Context, _ string) (bool, error) {
+	return m.imageExists, m.imageExistsErr
+}
+
+func (m *startMockRuntime) BuildImage(_ context.Context, opts runtime.BuildOptions) (string, error) {
+	m.buildCalled = true
+	m.buildOpts = opts
+	if m.buildErr != nil {
+		return "", m.buildErr
+	}
+	return opts.Tag, nil
+}
+
+func (m *startMockRuntime) Run(context.Context, runtime.RunOptions) (string, error) {
+	return "", fmt.Errorf("unexpected call to Run")
+}
+
+func (m *startMockRuntime) Stop(context.Context, string) error {
+	return fmt.Errorf("unexpected call to Stop")
+}
+
+func (m *startMockRuntime) Remove(context.Context, string) error {
+	return fmt.Errorf("unexpected call to Remove")
+}
+
+func (m *startMockRuntime) Status(context.Context, string) (string, error) {
+	return "", fmt.Errorf("unexpected call to Status")
+}
+
+func (m *startMockRuntime) Inspect(context.Context, string) (*runtime.ContainerInfo, error) {
+	return nil, fmt.Errorf("unexpected call to Inspect")
+}
+
+func (m *startMockRuntime) Logs(context.Context, string, bool, int) error {
+	return fmt.Errorf("unexpected call to Logs")
+}
+
+func TestResolveImage(t *testing.T) {
+	t.Run("returns default image when no toolchain", func(t *testing.T) {
+		cfg := &config.Config{
+			Image: "gsoci.azurecr.io/giantswarm/klaus:latest",
+		}
+
+		image, err := resolveImage(context.Background(), cfg, nil, "", io.Discard)
+		if err != nil {
+			t.Fatalf("resolveImage() error: %v", err)
+		}
+		if image != "gsoci.azurecr.io/giantswarm/klaus:latest" {
+			t.Errorf("image = %q, want %q", image, "gsoci.azurecr.io/giantswarm/klaus:latest")
+		}
+	})
+
+	t.Run("returns prebuilt toolchain image", func(t *testing.T) {
+		cfg := &config.Config{
+			Image: "gsoci.azurecr.io/giantswarm/klaus:latest",
+			Toolchain: &config.Toolchain{
+				Image:    "gsoci.azurecr.io/giantswarm/klaus-go:1.0.0",
+				Prebuilt: true,
+			},
+		}
+
+		image, err := resolveImage(context.Background(), cfg, nil, "", io.Discard)
+		if err != nil {
+			t.Fatalf("resolveImage() error: %v", err)
+		}
+		if image != "gsoci.azurecr.io/giantswarm/klaus-go:1.0.0" {
+			t.Errorf("image = %q, want %q", image, "gsoci.azurecr.io/giantswarm/klaus-go:1.0.0")
+		}
+	})
+
+	t.Run("prebuilt toolchain ignores default image", func(t *testing.T) {
+		cfg := &config.Config{
+			Image: "gsoci.azurecr.io/giantswarm/klaus:v2",
+			Toolchain: &config.Toolchain{
+				Image:    "gsoci.azurecr.io/giantswarm/klaus-python:1.0.0",
+				Prebuilt: true,
+			},
+		}
+
+		image, err := resolveImage(context.Background(), cfg, nil, "", io.Discard)
+		if err != nil {
+			t.Fatalf("resolveImage() error: %v", err)
+		}
+		if image != "gsoci.azurecr.io/giantswarm/klaus-python:1.0.0" {
+			t.Errorf("image = %q, want %q", image, "gsoci.azurecr.io/giantswarm/klaus-python:1.0.0")
+		}
+	})
+
+	t.Run("builds composite image for non-prebuilt toolchain", func(t *testing.T) {
+		dir := t.TempDir()
+		rt := &startMockRuntime{name: "docker", imageExists: false}
+		cfg := &config.Config{
+			Image: "gsoci.azurecr.io/giantswarm/klaus:latest",
+			Toolchain: &config.Toolchain{
+				Image: "golang:1.25",
+			},
+		}
+
+		image, err := resolveImage(context.Background(), cfg, rt, dir, io.Discard)
+		if err != nil {
+			t.Fatalf("resolveImage() error: %v", err)
+		}
+		if image == "" {
+			t.Fatal("resolveImage() returned empty image")
+		}
+		if !strings.HasPrefix(image, "klausctl-toolchain:") {
+			t.Errorf("expected composite tag prefix, got %q", image)
+		}
+		if !rt.buildCalled {
+			t.Error("expected BuildImage to be called for non-prebuilt toolchain")
+		}
+	})
+
+	t.Run("skips build when composite image exists locally", func(t *testing.T) {
+		dir := t.TempDir()
+		rt := &startMockRuntime{name: "docker", imageExists: true}
+		cfg := &config.Config{
+			Image: "gsoci.azurecr.io/giantswarm/klaus:latest",
+			Toolchain: &config.Toolchain{
+				Image: "golang:1.25",
+			},
+		}
+
+		image, err := resolveImage(context.Background(), cfg, rt, dir, io.Discard)
+		if err != nil {
+			t.Fatalf("resolveImage() error: %v", err)
+		}
+		if !strings.HasPrefix(image, "klausctl-toolchain:") {
+			t.Errorf("expected composite tag prefix, got %q", image)
+		}
+		if rt.buildCalled {
+			t.Error("BuildImage should not be called when image exists locally")
+		}
+	})
+
+	t.Run("returns error on composite build failure", func(t *testing.T) {
+		dir := t.TempDir()
+		rt := &startMockRuntime{
+			name:        "docker",
+			imageExists: false,
+			buildErr:    fmt.Errorf("build failed"),
+		}
+		cfg := &config.Config{
+			Image: "gsoci.azurecr.io/giantswarm/klaus:latest",
+			Toolchain: &config.Toolchain{
+				Image: "golang:1.25",
+			},
+		}
+
+		_, err := resolveImage(context.Background(), cfg, rt, dir, io.Discard)
+		if err == nil {
+			t.Fatal("resolveImage() should return error on build failure")
+		}
+		if !strings.Contains(err.Error(), "building toolchain image") {
+			t.Errorf("error should wrap build failure: %v", err)
+		}
+	})
+
+	t.Run("composite build includes extra packages", func(t *testing.T) {
+		dir := t.TempDir()
+		rt := &startMockRuntime{name: "docker", imageExists: false}
+		cfg := &config.Config{
+			Image: "gsoci.azurecr.io/giantswarm/klaus:latest",
+			Toolchain: &config.Toolchain{
+				Image:    "golang:1.25",
+				Packages: []string{"make", "gcc"},
+			},
+		}
+
+		image, err := resolveImage(context.Background(), cfg, rt, dir, io.Discard)
+		if err != nil {
+			t.Fatalf("resolveImage() error: %v", err)
+		}
+		if !strings.HasPrefix(image, "klausctl-toolchain:") {
+			t.Errorf("expected composite tag prefix, got %q", image)
+		}
+
+		// Verify a different tag is produced vs without packages.
+		cfgNoPackages := &config.Config{
+			Image: "gsoci.azurecr.io/giantswarm/klaus:latest",
+			Toolchain: &config.Toolchain{
+				Image: "golang:1.25",
+			},
+		}
+		rt2 := &startMockRuntime{name: "docker", imageExists: false}
+		imageNoPackages, err := resolveImage(context.Background(), cfgNoPackages, rt2, t.TempDir(), io.Discard)
+		if err != nil {
+			t.Fatalf("resolveImage() error: %v", err)
+		}
+
+		if image == imageNoPackages {
+			t.Error("toolchain with packages should produce a different tag than without")
+		}
+	})
+}
+
+func TestStartSubcommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "start" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'start' subcommand to be registered on rootCmd")
+	}
+}
+
+func TestStartWorkspaceFlag(t *testing.T) {
+	f := startCmd.Flags().Lookup("workspace")
+	if f == nil {
+		t.Fatal("expected --workspace flag to be registered")
+	}
+}

--- a/pkg/devenv/devenv_test.go
+++ b/pkg/devenv/devenv_test.go
@@ -3,6 +3,7 @@ package devenv
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -198,7 +199,7 @@ func TestBuild(t *testing.T) {
 		rt := &mockRuntime{name: "docker", imageExists: true}
 		tc := &config.Toolchain{Image: "golang:1.25"}
 
-		tag, err := Build(context.Background(), rt, "klaus:v1", tc, dir)
+		tag, err := Build(context.Background(), rt, "klaus:v1", tc, dir, io.Discard)
 		if err != nil {
 			t.Fatalf("Build() returned error: %v", err)
 		}
@@ -224,7 +225,7 @@ func TestBuild(t *testing.T) {
 			Packages: []string{"make"},
 		}
 
-		tag, err := Build(context.Background(), rt, "klaus:v1", tc, dir)
+		tag, err := Build(context.Background(), rt, "klaus:v1", tc, dir, io.Discard)
 		if err != nil {
 			t.Fatalf("Build() returned error: %v", err)
 		}
@@ -254,13 +255,13 @@ func TestBuild(t *testing.T) {
 		tc := &config.Toolchain{Image: "golang:1.25"}
 
 		rt1 := &mockRuntime{name: "docker", imageExists: true}
-		tag1, err := Build(context.Background(), rt1, "klaus:v1", tc, dir1)
+		tag1, err := Build(context.Background(), rt1, "klaus:v1", tc, dir1, io.Discard)
 		if err != nil {
 			t.Fatalf("first Build() returned error: %v", err)
 		}
 
 		rt2 := &mockRuntime{name: "docker", imageExists: true}
-		tag2, err := Build(context.Background(), rt2, "klaus:v1", tc, dir2)
+		tag2, err := Build(context.Background(), rt2, "klaus:v1", tc, dir2, io.Discard)
 		if err != nil {
 			t.Fatalf("second Build() returned error: %v", err)
 		}
@@ -278,7 +279,7 @@ func TestBuild(t *testing.T) {
 			Packages: []string{"make", "gcc"},
 		}
 
-		_, err := Build(context.Background(), rt, "klaus:v1", tc, dir)
+		_, err := Build(context.Background(), rt, "klaus:v1", tc, dir, io.Discard)
 		if err != nil {
 			t.Fatalf("Build() returned error: %v", err)
 		}
@@ -310,7 +311,7 @@ func TestBuild(t *testing.T) {
 		}
 		tc := &config.Toolchain{Image: "golang:1.25"}
 
-		_, err := Build(context.Background(), rt, "klaus:v1", tc, dir)
+		_, err := Build(context.Background(), rt, "klaus:v1", tc, dir, io.Discard)
 		if err == nil {
 			t.Fatal("Build() should return error on build failure")
 		}
@@ -327,7 +328,7 @@ func TestBuild(t *testing.T) {
 		}
 		tc := &config.Toolchain{Image: "golang:1.25"}
 
-		_, err := Build(context.Background(), rt, "klaus:v1", tc, dir)
+		_, err := Build(context.Background(), rt, "klaus:v1", tc, dir, io.Discard)
 		if err == nil {
 			t.Fatal("Build() should return error on ImageExists failure")
 		}


### PR DESCRIPTION
## Summary

- Resolve toolchain images (prebuilt or composite) in `klausctl start` and use the resolved image for container run, instance state, and status display ([#19](https://github.com/giantswarm/klausctl/issues/19))
- Apply review fixes to `pkg/devenv` composite image builder:
  - Fix double error wrapping in `resolveImage` (was: `building toolchain image: building toolchain image: ...`)
  - Move "Building toolchain image" status message into `devenv.Build` so it only prints when a build actually happens, not on cache hits
  - Only print "Pulling" for remote images (default or prebuilt), not for locally-built composite images
  - Include Dockerfile template content in `CompositeTag` hash so template changes (e.g. Node.js version bump) automatically invalidate cached images
  - Document Debian/Ubuntu base image requirement in `GenerateDockerfile` godoc

## Test plan

- [x] All existing tests pass (`go test ./pkg/devenv/ ./cmd/` -- 23 tests)
- [ ] Manual: `klausctl start` with no toolchain configured uses default image and prints "Pulling"
- [ ] Manual: `klausctl start` with `prebuilt: true` toolchain uses toolchain image and prints "Pulling"
- [ ] Manual: `klausctl start` with non-prebuilt toolchain builds composite image, prints "Building" only on first run, skips on subsequent runs
- [ ] Manual: `klausctl status` shows the resolved image (composite tag or prebuilt image)

Made with [Cursor](https://cursor.com)