### PR TITLE
Fix CircleCI config binary name from template to klausctl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,21 +9,7 @@ workflows:
       - architect/go-build:
           context: architect
           name: go-build
-          binary: template
+          binary: klausctl
           filters:
-            # Trigger job also on git tag.
             tags:
               only: /^v.*/
-      # - architect/push-to-registries:
-      #     context: architect
-      #     name: push-to-registries
-      #     requires:
-      #       - go-build
-      #     filters:
-      #       # Trigger job also on git tag.
-      #       tags:
-      #         only: /^v.*/
-      #       branches:
-      #         ignore:
-      #           - main
-      #           - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `klausctl toolchain init --name <name>` to scaffold a new toolchain image repository with Dockerfiles, Makefile, CI config, and README. ([#20](https://github.com/giantswarm/klausctl/issues/20))
 - Add `Images()` and `Pull()` methods to `Runtime` interface. ([#20](https://github.com/giantswarm/klausctl/issues/20))
 
+### Fixed
+
+- Fix CircleCI config to use `klausctl` binary name instead of `template` from project scaffold. ([#9](https://github.com/giantswarm/klausctl/issues/9))
+
 ### Changed
 
 - `klausctl stop` is now idempotent -- exits 0 when no instance is running.


### PR DESCRIPTION
## Summary

- Fix `binary: template` to `binary: klausctl` in the CircleCI config (leftover from project scaffold).
- Clean up the commented-out `push-to-registries` block -- klausctl is a CLI tool released via GoReleaser, not a container image.
- Rename workflow from `test` to `build` to match the convention in giantswarm/klaus.

Combined with the existing `auto-release.yaml` and `.goreleaser.yaml` (from #10), this addresses the core CI items from #9. The architect orb handles build, test, and linting. GoReleaser handles cross-platform release builds.

## Test plan

- [ ] CircleCI `go-build` job passes with the corrected binary name

Ref #9