### PR TITLE
chore: align Go toolchain to go 1.25.0 with toolchain go1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/giantswarm/klausctl
 
-go 1.25
+go 1.25.0
+
+toolchain go1.26.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Summary
- Update `go.mod` from `go 1.25` to `go 1.25.0` with `toolchain go1.26.0`
- Aligns with other Giant Swarm repos (mcp-kubernetes, muster, etc.)

## Test plan
- [x] `go build ./...` passes
- [x] `go mod tidy` produces no changes

Made with [Cursor](https://cursor.com)