### PR TITLE
Add prompt/result CLI commands, fix MCP type inference, and harden helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix MCP config rendering for HTTP servers: auto-infer `"type": "http"` for URL-based entries and `"type": "stdio"` for command-based entries. Without the explicit type field, Claude Code misidentifies HTTP servers as stdio and hangs during initialization.
+
 ### Added
 
 - Add `--env`, `--env-forward`, `--permission-mode`, `--model`, `--system-prompt`, and `--max-budget` flags to `klausctl create`, unifying config overrides between the CLI and MCP tool.
+- Add `klausctl prompt` and `klausctl result` CLI commands to send prompts to and retrieve results from running klaus instances, mirroring the `klaus_prompt` and `klaus_result` MCP tools. `prompt` supports `--blocking` to wait for completion and `--message`/`-m` for the prompt text; both support `--output json`.
 - Expose full config options in `klaus_create` MCP tool: `envVars`, `envForward`, `mcpServers`, `maxBudgetUsd`, `permissionMode`, `model`, and `systemPrompt` parameters, enabling programmatic instance creation without manual config editing. ([#46](https://github.com/giantswarm/klausctl/issues/46))
 - Add `klaus_prompt` and `klaus_result` MCP tools to bridge the management and agent planes. `klaus_prompt` sends prompts to running instances with optional blocking mode, and `klaus_result` retrieves the agent's last response. Includes a lightweight MCP HTTP client (`pkg/mcpclient/`) with per-instance session caching. ([#45](https://github.com/giantswarm/klausctl/issues/45))
 - Enhance `klaus_status` to include the agent's internal status (`agent_status` field) alongside the container status when the instance is running, eliminating an extra round-trip. ([#45](https://github.com/giantswarm/klausctl/issues/45))

--- a/cmd/color.go
+++ b/cmd/color.go
@@ -42,3 +42,14 @@ func bold(s string) string {
 	}
 	return "\033[1m" + s + "\033[0m"
 }
+
+func colorStatus(status string) string {
+	switch status {
+	case "started", "completed":
+		return green(status)
+	case "error", "failed":
+		return yellow(status)
+	default:
+		return status
+	}
+}

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -1,0 +1,222 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/instance"
+	"github.com/giantswarm/klausctl/pkg/mcpclient"
+	"github.com/giantswarm/klausctl/pkg/runtime"
+)
+
+var (
+	promptMessage  string
+	promptBlocking bool
+	promptOutput   string
+)
+
+var promptCmd = &cobra.Command{
+	Use:   "prompt [name]",
+	Short: "Send a prompt to a running klaus instance",
+	Long: `Send a prompt message to the agent running inside a klaus instance.
+
+By default the command returns immediately after the prompt is accepted.
+Use --blocking to wait for the agent to finish and print the result.
+
+Examples:
+
+  klausctl prompt dev -m "List all Go files in the workspace"
+  klausctl prompt dev -m "Fix the failing test" --blocking
+  klausctl prompt dev -m "Refactor the handler" -o json`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runPrompt,
+}
+
+func init() {
+	promptCmd.Flags().StringVarP(&promptMessage, "message", "m", "", "prompt message to send to the agent (required)")
+	promptCmd.Flags().BoolVar(&promptBlocking, "blocking", false, "wait for the agent to complete and return the result")
+	promptCmd.Flags().StringVarP(&promptOutput, "output", "o", "text", "output format: text, json")
+	_ = promptCmd.MarkFlagRequired("message")
+	rootCmd.AddCommand(promptCmd)
+}
+
+type promptCLIResult struct {
+	Instance  string `json:"instance"`
+	Status    string `json:"status"`
+	SessionID string `json:"session_id,omitempty"`
+	Result    string `json:"result,omitempty"`
+}
+
+func runPrompt(cmd *cobra.Command, args []string) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	out := cmd.OutOrStdout()
+
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+	if err := config.MigrateLayout(paths); err != nil {
+		return fmt.Errorf("migrating config layout: %w", err)
+	}
+
+	instanceName, err := resolveOptionalInstanceName(args, "prompt", cmd.ErrOrStderr())
+	if err != nil {
+		return err
+	}
+	paths = paths.ForInstance(instanceName)
+
+	inst, err := instance.Load(paths)
+	if err != nil {
+		return fmt.Errorf("no klaus instance found for %q; run 'klausctl create %s <workspace>' first", instanceName, instanceName)
+	}
+
+	rt, err := runtime.New(inst.Runtime)
+	if err != nil {
+		return err
+	}
+
+	status, err := rt.Status(ctx, inst.ContainerName())
+	if err != nil {
+		return fmt.Errorf("instance %q: unable to determine status: %w", instanceName, err)
+	}
+	if status != "running" {
+		return fmt.Errorf("instance %q is not running (status: %s); run 'klausctl start %s' first", instanceName, status, instanceName)
+	}
+
+	baseURL := fmt.Sprintf("http://localhost:%d/mcp", inst.Port)
+
+	client := mcpclient.New(buildVersion)
+	defer client.Close()
+
+	toolResult, err := client.Prompt(ctx, instanceName, baseURL, promptMessage)
+	if err != nil {
+		return fmt.Errorf("sending prompt to %q: %w", instanceName, err)
+	}
+
+	if !promptBlocking {
+		result := promptCLIResult{
+			Instance:  instanceName,
+			Status:    "started",
+			SessionID: client.SessionID(instanceName),
+			Result:    extractMCPText(toolResult),
+		}
+		return renderPromptResult(out, result)
+	}
+
+	agentResult, err := waitForAgentResult(ctx, instanceName, baseURL, client)
+	if err != nil {
+		return fmt.Errorf("waiting for result from %q: %w", instanceName, err)
+	}
+
+	result := promptCLIResult{
+		Instance:  instanceName,
+		Status:    "completed",
+		SessionID: client.SessionID(instanceName),
+		Result:    agentResult,
+	}
+	return renderPromptResult(out, result)
+}
+
+func renderPromptResult(out io.Writer, result promptCLIResult) error {
+	if promptOutput == "json" {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	fmt.Fprintf(out, "Instance: %s\n", result.Instance)
+	fmt.Fprintf(out, "Status:   %s\n", colorStatus(result.Status))
+	if result.SessionID != "" {
+		fmt.Fprintf(out, "Session:  %s\n", result.SessionID)
+	}
+	if result.Result != "" {
+		fmt.Fprintf(out, "\n%s\n", result.Result)
+	}
+	return nil
+}
+
+// waitForAgentResult polls the agent's status until the task completes, then
+// retrieves the result.
+func waitForAgentResult(ctx context.Context, name, baseURL string, client *mcpclient.Client) (string, error) {
+	poll := 2 * time.Second
+	const maxPoll = 30 * time.Second
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(poll):
+		}
+
+		statusResult, err := client.Status(ctx, name, baseURL)
+		if err != nil {
+			return "", fmt.Errorf("polling status: %w", err)
+		}
+
+		if agentTerminalStatuses[parseAgentStatusField(statusResult)] {
+			break
+		}
+
+		if poll < maxPoll {
+			poll = min(poll*2, maxPoll)
+		}
+	}
+
+	resultResp, err := client.Result(ctx, name, baseURL)
+	if err != nil {
+		return "", fmt.Errorf("fetching result: %w", err)
+	}
+
+	return extractMCPText(resultResp), nil
+}
+
+var agentTerminalStatuses = map[string]bool{
+	"completed": true,
+	"error":     true,
+	"failed":    true,
+}
+
+// extractMCPText returns the concatenated text content from an MCP tool result.
+// Only TextContent items are extracted. Non-text content types (images, etc.)
+// are silently skipped; callers needing the raw payload should inspect
+// result.Content directly.
+func extractMCPText(result *mcp.CallToolResult) string {
+	if result == nil {
+		return ""
+	}
+
+	var parts []string
+	for _, c := range result.Content {
+		if tc, ok := c.(mcp.TextContent); ok {
+			parts = append(parts, tc.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// parseAgentStatusField extracts the "status" field from a JSON tool result.
+func parseAgentStatusField(result *mcp.CallToolResult) string {
+	text := extractMCPText(result)
+	if text == "" {
+		return ""
+	}
+	var parsed struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(text), &parsed); err == nil && parsed.Status != "" {
+		return parsed.Status
+	}
+	return text
+}

--- a/cmd/prompt_test.go
+++ b/cmd/prompt_test.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestExtractMCPText(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *mcp.CallToolResult
+		want   string
+	}{
+		{
+			name:   "nil result",
+			result: nil,
+			want:   "",
+		},
+		{
+			name:   "empty content",
+			result: &mcp.CallToolResult{},
+			want:   "",
+		},
+		{
+			name: "single text content",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{Type: "text", Text: "hello"},
+				},
+			},
+			want: "hello",
+		},
+		{
+			name: "multiple text content items",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{Type: "text", Text: "line1"},
+					mcp.TextContent{Type: "text", Text: "line2"},
+				},
+			},
+			want: "line1\nline2",
+		},
+		{
+			name: "non-text content is skipped",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.ImageContent{Type: "image", MIMEType: "image/png", Data: "abc"},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "mixed content types",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{Type: "text", Text: "before"},
+					mcp.ImageContent{Type: "image", MIMEType: "image/png", Data: "abc"},
+					mcp.TextContent{Type: "text", Text: "after"},
+				},
+			},
+			want: "before\nafter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractMCPText(tt.result)
+			if got != tt.want {
+				t.Errorf("extractMCPText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAgentStatusField(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *mcp.CallToolResult
+		want   string
+	}{
+		{
+			name:   "nil result",
+			result: nil,
+			want:   "",
+		},
+		{
+			name: "valid JSON with status field",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{Type: "text", Text: `{"status":"completed","result":"done"}`},
+				},
+			},
+			want: "completed",
+		},
+		{
+			name: "non-JSON text returns raw text",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{Type: "text", Text: "some plain text"},
+				},
+			},
+			want: "some plain text",
+		},
+		{
+			name: "JSON without status field returns raw text",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{Type: "text", Text: `{"other":"field"}`},
+				},
+			},
+			want: `{"other":"field"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAgentStatusField(tt.result)
+			if got != tt.want {
+				t.Errorf("parseAgentStatusField() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestColorStatus(t *testing.T) {
+	colorEnabled = false
+	t.Cleanup(func() { colorEnabled = detectColor() })
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"started", "started"},
+		{"completed", "completed"},
+		{"error", "error"},
+		{"failed", "failed"},
+		{"unknown", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := colorStatus(tt.input)
+			if got != tt.want {
+				t.Errorf("colorStatus(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/result.go
+++ b/cmd/result.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/instance"
+	"github.com/giantswarm/klausctl/pkg/mcpclient"
+	"github.com/giantswarm/klausctl/pkg/runtime"
+)
+
+var resultOutput string
+
+var resultCmd = &cobra.Command{
+	Use:   "result [name]",
+	Short: "Retrieve the result from a klaus instance",
+	Long: `Retrieve the result from the last prompt sent to a klaus instance.
+
+Examples:
+
+  klausctl result dev
+  klausctl result dev -o json`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runResult,
+}
+
+func init() {
+	resultCmd.Flags().StringVarP(&resultOutput, "output", "o", "text", "output format: text, json")
+	rootCmd.AddCommand(resultCmd)
+}
+
+type resultCLIResult struct {
+	Instance string `json:"instance"`
+	Status   string `json:"status"`
+	Result   string `json:"result,omitempty"`
+}
+
+func runResult(cmd *cobra.Command, args []string) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	out := cmd.OutOrStdout()
+
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+	if err := config.MigrateLayout(paths); err != nil {
+		return fmt.Errorf("migrating config layout: %w", err)
+	}
+
+	instanceName, err := resolveOptionalInstanceName(args, "result", cmd.ErrOrStderr())
+	if err != nil {
+		return err
+	}
+	paths = paths.ForInstance(instanceName)
+
+	inst, err := instance.Load(paths)
+	if err != nil {
+		return fmt.Errorf("no klaus instance found for %q; run 'klausctl create %s <workspace>' first", instanceName, instanceName)
+	}
+
+	rt, err := runtime.New(inst.Runtime)
+	if err != nil {
+		return err
+	}
+
+	status, err := rt.Status(ctx, inst.ContainerName())
+	if err != nil {
+		return fmt.Errorf("instance %q: unable to determine status: %w", instanceName, err)
+	}
+	if status != "running" {
+		return fmt.Errorf("instance %q is not running (status: %s); run 'klausctl start %s' first", instanceName, status, instanceName)
+	}
+
+	baseURL := fmt.Sprintf("http://localhost:%d/mcp", inst.Port)
+
+	client := mcpclient.New(buildVersion)
+	defer client.Close()
+
+	toolResult, err := client.Result(ctx, instanceName, baseURL)
+	if err != nil {
+		return fmt.Errorf("fetching result from %q: %w", instanceName, err)
+	}
+
+	text := extractMCPText(toolResult)
+
+	resultStatus := "completed"
+	if toolResult != nil && toolResult.IsError {
+		resultStatus = "error"
+	}
+
+	result := resultCLIResult{
+		Instance: instanceName,
+		Status:   resultStatus,
+		Result:   text,
+	}
+
+	return renderResultOutput(out, result)
+}
+
+func renderResultOutput(out io.Writer, result resultCLIResult) error {
+	if resultOutput == "json" {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	fmt.Fprintf(out, "Instance: %s\n", result.Instance)
+	fmt.Fprintf(out, "Status:   %s\n", colorStatus(result.Status))
+	if result.Result != "" {
+		fmt.Fprintf(out, "\n%s\n", result.Result)
+	}
+	return nil
+}

--- a/pkg/renderer/mcp.go
+++ b/pkg/renderer/mcp.go
@@ -9,9 +9,19 @@ import (
 // renderMCPConfig writes the .mcp.json file containing MCP server configuration.
 // The format wraps servers under "mcpServers" key, matching the Claude Code
 // expected format (same as the Helm chart's rendering).
+//
+// Claude Code requires an explicit "type" field ("http" or "stdio") for each
+// server entry. Without it, HTTP servers are misidentified as stdio, causing
+// the subprocess to hang. This function infers the type from the entry fields
+// when not explicitly set.
 func (r *Renderer) renderMCPConfig(servers map[string]any) error {
+	enriched := make(map[string]any, len(servers))
+	for name, v := range servers {
+		enriched[name] = inferMCPServerType(v)
+	}
+
 	data := map[string]any{
-		"mcpServers": servers,
+		"mcpServers": enriched,
 	}
 
 	content, err := json.MarshalIndent(data, "", "  ")
@@ -21,4 +31,34 @@ func (r *Renderer) renderMCPConfig(servers map[string]any) error {
 
 	path := filepath.Join(r.paths.RenderedDir, "mcp-config.json")
 	return writeFile(path, append(content, '\n'), 0o644)
+}
+
+// inferMCPServerType adds a "type" field to an MCP server entry when missing.
+// Entries with a "url" field are classified as "http"; entries with a "command"
+// field are classified as "stdio".
+func inferMCPServerType(entry any) any {
+	m, ok := entry.(map[string]any)
+	if !ok {
+		return entry
+	}
+	if _, hasType := m["type"]; hasType {
+		return m
+	}
+
+	var inferredType string
+	if _, hasURL := m["url"]; hasURL {
+		inferredType = "http"
+	} else if _, hasCmd := m["command"]; hasCmd {
+		inferredType = "stdio"
+	}
+	if inferredType == "" {
+		return m
+	}
+
+	enriched := make(map[string]any, len(m)+1)
+	for k, v := range m {
+		enriched[k] = v
+	}
+	enriched["type"] = inferredType
+	return enriched
 }


### PR DESCRIPTION
## Summary

- **New CLI commands**: `klausctl prompt` (with `--blocking`, `-m`, `-o json`) and `klausctl result` mirror the existing `klaus_prompt` and `klaus_result` MCP tools, enabling CLI-based interaction with running agent instances.
- **MCP config fix**: Auto-infer `"type": "http"` for URL-based and `"type": "stdio"` for command-based MCP server entries during config rendering. Without the explicit type field, Claude Code misidentifies HTTP servers as stdio and hangs during initialization.
- **Robustness improvements**: Separate error paths when runtime status checks fail vs instance not running (avoids empty `(status: )` messages), nil-guard `toolResult` in result command, remove `extractMCPText` JSON fallback that could leak raw payloads into text output, avoid unnecessary map allocation in `inferMCPServerType`.
- **Code quality**: Move `colorStatus` to `color.go` alongside related formatting helpers, use guarded type assertions in renderer tests matching existing style, add unit tests for `extractMCPText`, `parseAgentStatusField`, and `colorStatus`.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./cmd/... ./pkg/renderer/...` passes
- [ ] Manual: `klausctl prompt dev -m "hello"` returns promptly with session info
- [ ] Manual: `klausctl prompt dev -m "hello" --blocking` waits and prints result
- [ ] Manual: `klausctl result dev` retrieves last result
- [ ] Manual: `klausctl prompt dev -m "hello" -o json` outputs valid JSON
- [ ] Manual: Verify MCP config renders `"type": "http"` for URL-based servers

Made with [Cursor](https://cursor.com)