### PR TITLE
Fix plugin validate rejecting commands-only plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `klausctl plugin validate` rejecting commands-only plugins by adding `commands/` to the recognized plugin content list. ([#69](https://github.com/giantswarm/klausctl/issues/69))
+
 ### Added
 
 - Add `klausctl plugin describe`, `klausctl personality describe`, and `klausctl toolchain describe` commands that fetch artifact metadata from the OCI registry without downloading content layers. Each supports `--output json` for scripting and `--source` for source selection. `personality describe` automatically resolves dependency metadata in text mode; use `--deps=false` to skip or `--deps` to include them in JSON output.

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -38,8 +38,8 @@ var pluginCmd = &cobra.Command{
 	Short: "Manage OCI plugins",
 	Long: `Commands for working with klaus OCI plugins.
 
-Plugins are OCI artifacts containing skills, hooks, agents, and MCP server
-configurations. They are published to the registry by CI and can be pulled
+Plugins are OCI artifacts containing skills, hooks, agents, commands, and MCP
+server configurations. They are published to the registry by CI and can be pulled
 locally for use with klausctl.`,
 }
 
@@ -52,6 +52,7 @@ A valid plugin directory must contain at least one of:
   - skills/     (with SKILL.md files)
   - agents/     (agent definition files)
   - hooks/      (hook configuration)
+  - commands/   (slash command definitions)
   - .mcp.json   (MCP server configuration)`,
 	Args: cobra.ExactArgs(1),
 	RunE: runPluginValidate,
@@ -77,7 +78,7 @@ var pluginPushCmd = &cobra.Command{
 	Long: `Push a local plugin directory as an OCI artifact to the registry.
 
 The directory must contain valid plugin content (skills/, agents/, hooks/,
-or .mcp.json) and a .claude-plugin/plugin.json manifest.
+commands/, or .mcp.json) and a .claude-plugin/plugin.json manifest.
 
 Accepts a full OCI reference with tag or a short name with tag:
 
@@ -162,7 +163,7 @@ func validatePluginDir(dir string, out io.Writer, outputFmt string) error {
 		return fmt.Errorf("not a directory: %s", dir)
 	}
 
-	recognized := []string{"skills", "agents", "hooks", ".mcp.json"}
+	recognized := []string{"skills", "agents", "hooks", "commands", ".mcp.json"}
 	var found []string
 	for _, name := range recognized {
 		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
@@ -171,7 +172,7 @@ func validatePluginDir(dir string, out io.Writer, outputFmt string) error {
 	}
 
 	if len(found) == 0 {
-		return fmt.Errorf("no recognized plugin content found in %s\nExpected at least one of: skills/, agents/, hooks/, .mcp.json", dir)
+		return fmt.Errorf("no recognized plugin content found in %s\nExpected at least one of: skills/, agents/, hooks/, commands/, .mcp.json", dir)
 	}
 
 	if outputFmt == "json" {

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -50,6 +50,21 @@ func TestValidatePluginDirWithAgents(t *testing.T) {
 	}
 }
 
+func TestValidatePluginDirWithCommands(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(dir, "commands"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "commands", "customer-update.md"), []byte("# Command"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validatePluginDir(dir, io.Discard, "text"); err != nil {
+		t.Errorf("validatePluginDir() error = %v", err)
+	}
+}
+
 func TestValidatePluginDirWithMCPConfig(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- Add `commands/` to the recognized plugin content list in `validatePluginDir`, fixing validation for commands-only plugins like `gs-ae`
- Update command descriptions (`plugin`, `plugin validate`, `plugin push`) to mention `commands/`
- Add `TestValidatePluginDirWithCommands` test case

Closes #69

## Test plan

- [x] Existing plugin validation tests pass
- [x] New `TestValidatePluginDirWithCommands` test passes
- [x] `go test ./cmd/ -run TestValidatePlugin -v` all green

Made with [Cursor](https://cursor.com)