### PR TITLE
Resolve plugin and toolchain deps in personality validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `klausctl plugin validate` rejecting commands-only plugins by adding `commands/` to the recognized plugin content list. ([#69](https://github.com/giantswarm/klausctl/issues/69))
-- `klausctl personality validate` now resolves plugin and toolchain references against the OCI registry by default, failing if any dependency cannot be found. Use `--resolve-deps=false` for offline-only validation. Supports `--source` for source selection.
 
 ### Added
 
@@ -21,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `klausctl personality validate` now resolves plugin and toolchain references against the OCI registry by default, failing if any dependency cannot be found. Use `--resolve-deps=false` for offline-only validation. Supports `--source` for source selection.
 - Upgrade `klaus-oci` to v0.0.9: common metadata (name, description, author, homepage, repository, license, keywords) moves from OCI config blobs into `io.giantswarm.klaus.*` manifest annotations for all artifact types. Config blobs now contain only type-specific data (discovered components for plugins, composition for personalities). Toolchain annotations switch from `org.opencontainers.image.*` to `io.giantswarm.klaus.*`. Existing artifacts need to be re-pushed.
 - Upgrade `klaus-oci` to v0.0.8 for the unified `Personality` type and typed artifact operations:
   - `PersonalitySpec` replaced by `Personality` with `Toolchain` field (`ToolchainReference`) instead of `Image` string.


### PR DESCRIPTION
## Summary

- `klausctl personality validate` now resolves plugin and toolchain references against the OCI registry by default, failing if any dependency cannot be found (e.g. a plugin repository that does not exist like `kubernetes`).
- Adds `--resolve-deps` flag (default `true`) and `--source` flag to `personality validate`. Use `--resolve-deps=false` for offline-only structural validation.
- All dependency failures are collected and reported together (not fail-fast), giving users the full picture in a single run.

## Changes

- **Dependency resolution**: After structural validation passes, each plugin and toolchain reference is resolved against the OCI registry via `validatePersonalityDeps` / `resolvePersonalityDeps`.
- **Signal handling**: `runPersonalityValidate` creates a `signal.NotifyContext` for graceful Ctrl+C handling, consistent with all other `run*` functions.
- **Testability**: Extracted `resolvePersonalityDeps` so the core resolution loop can be unit-tested independently.
- **CHANGELOG**: Entry under "Changed" (new behavior, not a bug fix).

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `TestValidatePersonalityDepsNoDeps` verifies the no-deps fast path
- [x] `TestResolvePersonalityDepsCollectsAllErrors` verifies all dependency errors are collected (toolchain + 2 plugins) rather than failing on the first
- [x] Flag registration assertions for `--source` and `--resolve-deps`
- [x] CI green (CircleCI go-build, gitleaks)