### PR TITLE
feat: create git worktrees for workspace isolation

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/giantswarm/klausctl/pkg/config"
 	"github.com/giantswarm/klausctl/pkg/orchestrator"
+	"github.com/giantswarm/klausctl/pkg/worktree"
 )
 
 var (
@@ -29,6 +30,7 @@ var (
 	createSystemPrompt string
 	createMaxBudget    float64
 	createSource       string
+	createNoIsolate    bool
 )
 
 var createCmd = &cobra.Command{
@@ -62,10 +64,11 @@ func init() {
 	createCmd.Flags().StringArrayVar(&createSecretFile, "secret-file", nil, "secret file /container/path=secret-name (repeatable)")
 	createCmd.Flags().StringArrayVar(&createMcpServer, "mcpserver", nil, "managed MCP server name (repeatable)")
 	createCmd.Flags().StringVar(&createSource, "source", "", "resolve artifact short names against a specific source")
+	createCmd.Flags().BoolVar(&createNoIsolate, "no-isolate", false, "skip git worktree creation and bind-mount workspace directly")
 	rootCmd.AddCommand(createCmd)
 }
 
-func runCreate(cmd *cobra.Command, args []string) error {
+func runCreate(cmd *cobra.Command, args []string) (retErr error) {
 	instanceName := args[0]
 	if err := config.ValidateInstanceName(instanceName); err != nil {
 		return err
@@ -129,6 +132,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	opts := config.CreateOptions{
 		Name:           instanceName,
 		Workspace:      workspace,
+		NoIsolate:      createNoIsolate,
 		Personality:    personality,
 		Toolchain:      toolchain,
 		Plugins:        plugins,
@@ -177,6 +181,15 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	cfg, err := config.GenerateInstanceConfig(paths, opts)
 	if err != nil {
 		return err
+	}
+
+	// Clean up the worktree if any subsequent step fails.
+	if cfg.WorktreePath != "" {
+		defer func() {
+			if retErr != nil {
+				_ = worktree.Remove(cfg.Workspace, cfg.WorktreePath)
+			}
+		}()
 	}
 
 	if err := config.EnsureDir(instancePaths.InstanceDir); err != nil {

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -14,6 +14,7 @@ import (
 	"github.com/giantswarm/klausctl/pkg/config"
 	"github.com/giantswarm/klausctl/pkg/instance"
 	"github.com/giantswarm/klausctl/pkg/runtime"
+	"github.com/giantswarm/klausctl/pkg/worktree"
 )
 
 var deleteYes bool
@@ -58,6 +59,14 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	if !deleteYes {
 		if err := confirmDelete(cmd, name); err != nil {
 			return err
+		}
+	}
+
+	// Load instance config to check for worktree before removing anything.
+	cfg, _ := config.Load(paths.ConfigFile)
+	if cfg != nil && cfg.WorktreePath != "" {
+		if err := worktree.Remove(cfg.Workspace, cfg.WorktreePath); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to remove git worktree: %v\n", err)
 		}
 	}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -88,6 +88,14 @@ func startInstance(cmd *cobra.Command, instanceName, workspaceOverride, configPa
 		}
 		return fmt.Errorf("checking workspace directory: %w", err)
 	}
+	if cfg.WorktreePath != "" {
+		if _, err := os.Stat(cfg.WorktreePath); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("worktree directory does not exist: %s", cfg.WorktreePath)
+			}
+			return fmt.Errorf("checking worktree directory: %w", err)
+		}
+	}
 
 	// Detect or validate container runtime.
 	rt, err := runtime.New(cfg.Runtime)
@@ -202,7 +210,12 @@ func startInstance(cmd *cobra.Command, instanceName, workspaceOverride, configPa
 		return fmt.Errorf("starting container: %w", err)
 	}
 
-	// Save instance state.
+	// Save instance state. Use the worktree path as the effective workspace
+	// when available so that status and list commands show the mounted path.
+	effectiveWorkspace := workspace
+	if cfg.WorktreePath != "" {
+		effectiveWorkspace = cfg.WorktreePath
+	}
 	inst = &instance.Instance{
 		Name:        instanceName,
 		ContainerID: containerID,
@@ -210,7 +223,7 @@ func startInstance(cmd *cobra.Command, instanceName, workspaceOverride, configPa
 		Personality: cfg.Personality,
 		Image:       image,
 		Port:        cfg.Port,
-		Workspace:   workspace,
+		Workspace:   effectiveWorkspace,
 		StartedAt:   time.Now(),
 	}
 	if err := inst.Save(paths); err != nil {
@@ -241,5 +254,6 @@ func startInstance(cmd *cobra.Command, instanceName, workspaceOverride, configPa
 func applyWorkspaceOverride(cfg *config.Config, workspaceOverride string) {
 	if workspaceOverride != "" {
 		cfg.Workspace = workspaceOverride
+		cfg.WorktreePath = "" // override disables worktree isolation
 	}
 }

--- a/internal/tools/instance/tools.go
+++ b/internal/tools/instance/tools.go
@@ -23,6 +23,7 @@ import (
 	"github.com/giantswarm/klausctl/pkg/orchestrator"
 	"github.com/giantswarm/klausctl/pkg/renderer"
 	"github.com/giantswarm/klausctl/pkg/runtime"
+	"github.com/giantswarm/klausctl/pkg/worktree"
 )
 
 // RegisterTools registers all instance lifecycle tools on the MCP server.
@@ -57,6 +58,7 @@ func registerCreate(s *mcpserver.MCPServer, sc *server.ServerContext) {
 		mcp.WithString("permissionMode", mcp.Description("Claude permission mode (overrides personality default): default, acceptEdits, bypassPermissions, dontAsk, plan, delegate")),
 		mcp.WithString("model", mcp.Description("Claude model (overrides personality default, e.g. sonnet, opus, claude-sonnet-4-20250514)")),
 		mcp.WithString("systemPrompt", mcp.Description("System prompt for the Claude agent (overrides personality default)")),
+		mcp.WithBoolean("noIsolate", mcp.Description("Skip git worktree creation and bind-mount workspace directly (default: false)")),
 	)
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleCreate(ctx, req, sc)
@@ -188,6 +190,7 @@ func handleCreate(ctx context.Context, req mcp.CallToolRequest, sc *server.Serve
 	createOpts := config.CreateOptions{
 		Name:           name,
 		Workspace:      workspace,
+		NoIsolate:      req.GetBool("noIsolate", false),
 		Personality:    personality,
 		Toolchain:      toolchain,
 		Plugins:        pluginArgs,
@@ -339,6 +342,14 @@ func handleDelete(ctx context.Context, req mcp.CallToolRequest, sc *server.Serve
 			return mcp.NewToolResultError(fmt.Sprintf("instance %q does not exist", name)), nil
 		}
 		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Remove git worktree if one was created for this instance.
+	cfg, _ := config.Load(paths.ConfigFile)
+	if cfg != nil && cfg.WorktreePath != "" {
+		if err := worktree.Remove(cfg.Workspace, cfg.WorktreePath); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("removing git worktree: %v", err)), nil
+		}
 	}
 
 	inst, _ := instance.Load(paths)
@@ -559,6 +570,14 @@ func startExistingInstance(ctx context.Context, name string, sc *server.ServerCo
 		}
 		return nil, fmt.Errorf("checking workspace directory: %w", err)
 	}
+	if cfg.WorktreePath != "" {
+		if _, err := os.Stat(cfg.WorktreePath); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("worktree directory does not exist: %s", cfg.WorktreePath)
+			}
+			return nil, fmt.Errorf("checking worktree directory: %w", err)
+		}
+	}
 
 	rt, err := runtime.New(cfg.Runtime)
 	if err != nil {
@@ -635,6 +654,10 @@ func startExistingInstance(ctx context.Context, name string, sc *server.ServerCo
 		return nil, fmt.Errorf("starting container: %w", err)
 	}
 
+	effectiveWorkspace := workspace
+	if cfg.WorktreePath != "" {
+		effectiveWorkspace = cfg.WorktreePath
+	}
 	inst = &instance.Instance{
 		Name:        name,
 		ContainerID: containerID,
@@ -642,7 +665,7 @@ func startExistingInstance(ctx context.Context, name string, sc *server.ServerCo
 		Personality: cfg.Personality,
 		Image:       image,
 		Port:        cfg.Port,
-		Workspace:   workspace,
+		Workspace:   effectiveWorkspace,
 		StartedAt:   time.Now(),
 	}
 	if err := inst.Save(paths); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -33,6 +34,11 @@ type Config struct {
 
 	// Workspace is the host directory to mount into the container at /workspace.
 	Workspace string `yaml:"workspace"`
+
+	// WorktreePath is the path to the git worktree created for this instance.
+	// When set, this path is bind-mounted instead of Workspace, and Workspace
+	// stores the original repository path for worktree lifecycle management.
+	WorktreePath string `yaml:"worktreePath,omitempty"`
 
 	// Port is the host port mapped to the container's MCP endpoint (8080).
 	Port int `yaml:"port"`
@@ -282,6 +288,10 @@ func (c *Config) applyDefaults() {
 func (c *Config) Validate() error {
 	if c.Workspace == "" {
 		return fmt.Errorf("workspace is required")
+	}
+
+	if c.WorktreePath != "" && !filepath.IsAbs(c.WorktreePath) {
+		return fmt.Errorf("worktreePath must be an absolute path, got %q", c.WorktreePath)
 	}
 
 	if c.Port < 1 || c.Port > 65535 {

--- a/pkg/config/generate.go
+++ b/pkg/config/generate.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/giantswarm/klausctl/pkg/worktree"
 )
 
 // CreateOptions defines user-facing parameters for klausctl create.
@@ -20,6 +22,11 @@ type CreateOptions struct {
 	Toolchain   string
 	Plugins     []string
 	Port        int
+
+	// NoIsolate disables git worktree creation even when the workspace is a
+	// git repository. When false (the default), a worktree is created
+	// automatically for git-backed workspaces.
+	NoIsolate bool
 
 	// Override fields applied after personality resolution.
 	EnvVars        map[string]string
@@ -70,6 +77,22 @@ func GenerateInstanceConfig(paths *Paths, opts CreateOptions) (*Config, error) {
 
 	cfg := DefaultConfig()
 	cfg.Workspace = workspace
+
+	// Create a git worktree for isolation when the workspace is a git repo.
+	if !opts.NoIsolate && worktree.IsGitRepo(workspace) {
+		instanceDir := filepath.Join(paths.InstancesDir, opts.Name)
+		wtPath := filepath.Join(instanceDir, "workspace")
+
+		if err := EnsureDir(instanceDir); err != nil {
+			return nil, fmt.Errorf("creating instance directory for worktree: %w", err)
+		}
+
+		if err := worktree.Create(workspace, wtPath); err != nil {
+			return nil, fmt.Errorf("creating git worktree: %w", err)
+		}
+
+		cfg.WorktreePath = wtPath
+	}
 
 	resolver := opts.SourceResolver
 	if resolver == nil {

--- a/pkg/config/worktree_integration_test.go
+++ b/pkg/config/worktree_integration_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// setupGitWorkspace creates a bare repo and a clone suitable for testing.
+func setupGitWorkspace(t *testing.T) (bare, clone string) {
+	t.Helper()
+
+	bare = filepath.Join(t.TempDir(), "origin.git")
+	gitRun(t, "", "init", "--bare", "--initial-branch=main", bare)
+
+	clone = filepath.Join(t.TempDir(), "workspace")
+	gitRun(t, "", "clone", bare, clone)
+	gitRun(t, clone, "config", "user.email", "test@test.com")
+	gitRun(t, clone, "config", "user.name", "Test")
+	gitRun(t, clone, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(clone, "README.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, clone, "add", ".")
+	gitRun(t, clone, "commit", "-m", "init")
+	gitRun(t, clone, "push", "-u", "origin", "main")
+	return bare, clone
+}
+
+func TestGenerateInstanceConfig_CreatesWorktreeForGitRepo(t *testing.T) {
+	_, clone := setupGitWorkspace(t)
+
+	base := t.TempDir()
+	paths := &Paths{
+		ConfigDir:        base,
+		InstancesDir:     filepath.Join(base, "instances"),
+		PluginsDir:       filepath.Join(base, "plugins"),
+		PersonalitiesDir: filepath.Join(base, "personalities"),
+	}
+
+	cfg, err := GenerateInstanceConfig(paths, CreateOptions{
+		Name:      "dev",
+		Workspace: clone,
+	})
+	if err != nil {
+		t.Fatalf("GenerateInstanceConfig() error: %v", err)
+	}
+
+	if cfg.WorktreePath == "" {
+		t.Fatal("expected WorktreePath to be set for git workspace")
+	}
+
+	expectedPath := filepath.Join(base, "instances", "dev", "workspace")
+	if cfg.WorktreePath != expectedPath {
+		t.Fatalf("expected WorktreePath=%q, got %q", expectedPath, cfg.WorktreePath)
+	}
+
+	// Verify the worktree was actually created with the expected content.
+	readme, err := os.ReadFile(filepath.Join(cfg.WorktreePath, "README.md"))
+	if err != nil {
+		t.Fatalf("reading README in worktree: %v", err)
+	}
+	if string(readme) != "hello" {
+		t.Fatalf("unexpected README content: %q", readme)
+	}
+
+	// Original workspace should be stored in cfg.Workspace.
+	if cfg.Workspace != clone {
+		t.Fatalf("expected Workspace=%q (original repo), got %q", clone, cfg.Workspace)
+	}
+
+	// Clean up the worktree to avoid git warnings.
+	gitRun(t, clone, "worktree", "remove", "--force", cfg.WorktreePath)
+}
+
+func TestGenerateInstanceConfig_NoIsolateSkipsWorktree(t *testing.T) {
+	_, clone := setupGitWorkspace(t)
+
+	base := t.TempDir()
+	paths := &Paths{
+		ConfigDir:        base,
+		InstancesDir:     filepath.Join(base, "instances"),
+		PluginsDir:       filepath.Join(base, "plugins"),
+		PersonalitiesDir: filepath.Join(base, "personalities"),
+	}
+
+	cfg, err := GenerateInstanceConfig(paths, CreateOptions{
+		Name:      "dev",
+		Workspace: clone,
+		NoIsolate: true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateInstanceConfig() error: %v", err)
+	}
+
+	if cfg.WorktreePath != "" {
+		t.Fatalf("expected WorktreePath to be empty with NoIsolate, got %q", cfg.WorktreePath)
+	}
+}
+
+func TestGenerateInstanceConfig_NonGitWorkspaceSkipsWorktree(t *testing.T) {
+	base := t.TempDir()
+	workspace := filepath.Join(base, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	paths := &Paths{
+		ConfigDir:        base,
+		InstancesDir:     filepath.Join(base, "instances"),
+		PluginsDir:       filepath.Join(base, "plugins"),
+		PersonalitiesDir: filepath.Join(base, "personalities"),
+	}
+
+	cfg, err := GenerateInstanceConfig(paths, CreateOptions{
+		Name:      "dev",
+		Workspace: workspace,
+	})
+	if err != nil {
+		t.Fatalf("GenerateInstanceConfig() error: %v", err)
+	}
+
+	if cfg.WorktreePath != "" {
+		t.Fatalf("expected WorktreePath to be empty for non-git workspace, got %q", cfg.WorktreePath)
+	}
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -149,8 +149,12 @@ func BuildVolumes(cfg *config.Config, paths *config.Paths, env map[string]string
 	var vols []runtime.Volume
 
 	workspace := config.ExpandPath(cfg.Workspace)
+	mountPath := workspace
+	if cfg.WorktreePath != "" {
+		mountPath = cfg.WorktreePath
+	}
 	vols = append(vols, runtime.Volume{
-		HostPath:      workspace,
+		HostPath:      mountPath,
 		ContainerPath: "/workspace",
 	})
 	env["CLAUDE_WORKSPACE"] = "/workspace"

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -1,0 +1,107 @@
+// Package worktree manages git worktrees for workspace isolation.
+// When a workspace path is a git repository, a worktree can be created
+// so each instance gets its own working tree while sharing .git/objects.
+package worktree
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// IsGitRepo reports whether the given directory is a git repository root
+// (has a .git directory). Nested worktrees (.git file) are not considered
+// since they cannot be used as the parent repository for new worktrees.
+func IsGitRepo(dir string) bool {
+	info, err := os.Stat(filepath.Join(dir, ".git"))
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
+// DefaultBranch returns the default branch of the remote "origin" in the given
+// git repository. It runs `git remote show origin` and parses the HEAD branch.
+// Falls back to "main" if the default branch cannot be determined.
+func DefaultBranch(repoDir string) (string, error) {
+	cmd := exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD")
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err == nil {
+		ref := strings.TrimSpace(string(out))
+		// refs/remotes/origin/main -> main
+		if branch, ok := strings.CutPrefix(ref, "refs/remotes/origin/"); ok {
+			return branch, nil
+		}
+	}
+
+	// Fallback: try ls-remote to determine HEAD.
+	cmd = exec.Command("git", "ls-remote", "--symref", "origin", "HEAD")
+	cmd.Dir = repoDir
+	out, err = cmd.Output()
+	if err != nil {
+		return "main", nil
+	}
+	// Output format: "ref: refs/heads/main\tHEAD\n..."
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "ref:") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				ref := parts[1]
+				if branch, ok := strings.CutPrefix(ref, "refs/heads/"); ok {
+					return branch, nil
+				}
+			}
+		}
+	}
+
+	return "main", nil
+}
+
+// Create creates a git worktree at worktreePath from the given repository
+// directory. It fetches origin, determines the default branch, and creates
+// a detached worktree at origin/<default-branch>.
+func Create(repoDir, worktreePath string) error {
+	// Fetch latest from origin.
+	fetchCmd := exec.Command("git", "fetch", "origin")
+	fetchCmd.Dir = repoDir
+	var fetchErr bytes.Buffer
+	fetchCmd.Stderr = &fetchErr
+	if err := fetchCmd.Run(); err != nil {
+		return fmt.Errorf("git fetch origin: %s: %w", strings.TrimSpace(fetchErr.String()), err)
+	}
+
+	branch, err := DefaultBranch(repoDir)
+	if err != nil {
+		return fmt.Errorf("determining default branch: %w", err)
+	}
+
+	// Create the worktree in detached HEAD mode pointing at origin/<branch>.
+	ref := "origin/" + branch
+	wtCmd := exec.Command("git", "worktree", "add", "--detach", worktreePath, ref)
+	wtCmd.Dir = repoDir
+	var wtErr bytes.Buffer
+	wtCmd.Stderr = &wtErr
+	if err := wtCmd.Run(); err != nil {
+		return fmt.Errorf("git worktree add %s: %s: %w", worktreePath, strings.TrimSpace(wtErr.String()), err)
+	}
+
+	return nil
+}
+
+// Remove removes a git worktree. It runs `git worktree remove --force` from
+// the parent repository. The repoDir is the original repository (not the
+// worktree itself).
+func Remove(repoDir, worktreePath string) error {
+	cmd := exec.Command("git", "worktree", "remove", "--force", worktreePath)
+	cmd.Dir = repoDir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git worktree remove %s: %s: %w", worktreePath, strings.TrimSpace(stderr.String()), err)
+	}
+	return nil
+}

--- a/pkg/worktree/worktree_test.go
+++ b/pkg/worktree/worktree_test.go
@@ -1,0 +1,151 @@
+package worktree
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// initBareRepo creates a bare repo with one commit and returns its path.
+func initBareRepo(t *testing.T) string {
+	t.Helper()
+
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	run(t, "", "git", "init", "--bare", "--initial-branch=main", bare)
+
+	// Create a clone, add a commit, push.
+	clone := filepath.Join(t.TempDir(), "clone")
+	run(t, "", "git", "clone", bare, clone)
+	run(t, clone, "git", "config", "user.email", "test@test.com")
+	run(t, clone, "git", "config", "user.name", "Test")
+	run(t, clone, "git", "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(clone, "README.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(t, clone, "git", "add", ".")
+	run(t, clone, "git", "commit", "-m", "init")
+	run(t, clone, "git", "push", "-u", "origin", "main")
+
+	return bare
+}
+
+// cloneRepo clones the bare repo and returns the clone path.
+func cloneRepo(t *testing.T, bare string) string {
+	t.Helper()
+	clone := filepath.Join(t.TempDir(), "workspace")
+	run(t, "", "git", "clone", bare, clone)
+	run(t, clone, "git", "config", "user.email", "test@test.com")
+	run(t, clone, "git", "config", "user.name", "Test")
+	return clone
+}
+
+func run(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+}
+
+func TestIsGitRepo(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	if !IsGitRepo(clone) {
+		t.Fatal("expected cloned repo to be detected as git repo")
+	}
+
+	nonGit := t.TempDir()
+	if IsGitRepo(nonGit) {
+		t.Fatal("expected non-git directory to not be detected as git repo")
+	}
+}
+
+func TestDefaultBranch(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	branch, err := DefaultBranch(clone)
+	if err != nil {
+		t.Fatalf("DefaultBranch() error: %v", err)
+	}
+	if branch != "main" {
+		t.Fatalf("expected default branch 'main', got %q", branch)
+	}
+}
+
+func TestCreateAndRemove(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	wtPath := filepath.Join(t.TempDir(), "worktree")
+
+	if err := Create(clone, wtPath); err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	// Verify the worktree directory exists and has the README.
+	readme := filepath.Join(wtPath, "README.md")
+	data, err := os.ReadFile(readme)
+	if err != nil {
+		t.Fatalf("reading README in worktree: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("unexpected README content: %q", data)
+	}
+
+	// Verify it's a git worktree (has .git file, not directory).
+	gitPath := filepath.Join(wtPath, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		t.Fatalf("stat .git in worktree: %v", err)
+	}
+	if info.IsDir() {
+		t.Fatal("expected .git to be a file in worktree, not a directory")
+	}
+
+	// Remove the worktree.
+	if err := Remove(clone, wtPath); err != nil {
+		t.Fatalf("Remove() error: %v", err)
+	}
+
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("expected worktree directory to be removed, stat err: %v", err)
+	}
+}
+
+func TestCreateMultipleWorktrees(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	wt1 := filepath.Join(t.TempDir(), "wt1")
+	wt2 := filepath.Join(t.TempDir(), "wt2")
+
+	if err := Create(clone, wt1); err != nil {
+		t.Fatalf("Create(wt1) error: %v", err)
+	}
+	if err := Create(clone, wt2); err != nil {
+		t.Fatalf("Create(wt2) error: %v", err)
+	}
+
+	// Both should have the README.
+	for _, wt := range []string{wt1, wt2} {
+		if _, err := os.ReadFile(filepath.Join(wt, "README.md")); err != nil {
+			t.Fatalf("missing README in %s: %v", wt, err)
+		}
+	}
+
+	// Clean up both.
+	if err := Remove(clone, wt1); err != nil {
+		t.Fatalf("Remove(wt1) error: %v", err)
+	}
+	if err := Remove(clone, wt2); err != nil {
+		t.Fatalf("Remove(wt2) error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- When the workspace path is a git repo, `klausctl create` now creates a git worktree in the instance directory and bind-mounts it instead of the original workspace, enabling parallel agents on the same repo without conflicts.
- Each worktree checks out `origin/<default-branch>` at the latest fetched state via `git fetch origin` + `git worktree add --detach`.
- `klausctl delete` cleans up the worktree via `git worktree remove --force`.
- `--no-isolate` flag (CLI) and `noIsolate` parameter (MCP `klaus_create`) opt out of worktree creation for direct bind-mount.
- Non-git workspaces continue to work with direct bind mount (unchanged behavior).

## Changes

- **New `pkg/worktree` package**: `IsGitRepo`, `DefaultBranch`, `Create`, `Remove` functions wrapping git CLI commands.
- **`pkg/config`**: Added `WorktreePath` field to `Config`, `NoIsolate` field to `CreateOptions`, worktree creation in `GenerateInstanceConfig`, path validation in `Validate`.
- **`cmd/create.go`**: Added `--no-isolate` flag, deferred worktree cleanup on failure.
- **`cmd/delete.go`**: Worktree removal before instance directory deletion.
- **`cmd/start.go`**: Worktree path validation, `applyWorkspaceOverride` clears `WorktreePath`.
- **`pkg/orchestrator`**: `BuildVolumes` uses `WorktreePath` for the `/workspace` mount when set.
- **`internal/tools/instance`**: MCP `klaus_create` accepts `noIsolate`, MCP `handleDelete` removes worktrees.

## Self-review findings addressed

- **Worktree cleanup on failure**: Deferred cleanup in `runCreate` removes orphaned worktrees if subsequent steps fail.
- **Workspace override clears WorktreePath**: `applyWorkspaceOverride` resets `WorktreePath` to avoid stale references.
- **MCP delete error handling**: Worktree removal errors surface as tool errors (not silently swallowed).
- **Path validation**: `Validate()` rejects non-absolute `WorktreePath` values.
- **IsGitRepo scope**: Only detects `.git` directories (not worktree `.git` files) to avoid nesting issues.

## Test plan

- [x] `pkg/worktree` unit tests: `IsGitRepo`, `DefaultBranch`, `Create`, `Remove`, multiple worktrees
- [x] `pkg/config` integration tests: worktree creation for git repos, `--no-isolate` skip, non-git workspace skip
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet ./...` clean
- [ ] Manual test: `klausctl create agent1 /path/to/git/repo` creates worktree
- [ ] Manual test: `klausctl create agent2 /path/to/git/repo` creates second worktree without conflict
- [ ] Manual test: `klausctl delete agent1` removes worktree
- [ ] Manual test: `klausctl create agent3 /path/to/git/repo --no-isolate` uses direct bind mount

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)