### PR TITLE
fix: serialize worktree operations with filesystem lock

### DIFF
--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
 
 // IsGitRepo reports whether the given directory is a git repository root
@@ -61,10 +62,41 @@ func DefaultBranch(repoDir string) (string, error) {
 	return "main", nil
 }
 
+// lockRepo acquires an exclusive filesystem lock on the source repository's
+// .git directory. This serializes worktree operations to prevent concurrent
+// git commands from corrupting worktree references.
+// The caller must call the returned unlock function when done.
+func lockRepo(repoDir string) (unlock func(), err error) {
+	lockPath := filepath.Join(repoDir, ".git", "klausctl.lock")
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening lock file %s: %w", lockPath, err)
+	}
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("acquiring lock on %s: %w", lockPath, err)
+	}
+
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}
+
 // Create creates a git worktree at worktreePath from the given repository
 // directory. It fetches origin, determines the default branch, and creates
 // a detached worktree at origin/<default-branch>.
+//
+// An exclusive filesystem lock is held for the duration of the operation to
+// prevent concurrent worktree creation from corrupting git references.
 func Create(repoDir, worktreePath string) error {
+	unlock, err := lockRepo(repoDir)
+	if err != nil {
+		return fmt.Errorf("locking repo: %w", err)
+	}
+	defer unlock()
+
 	// Fetch latest from origin.
 	fetchCmd := exec.Command("git", "fetch", "origin")
 	fetchCmd.Dir = repoDir
@@ -95,7 +127,16 @@ func Create(repoDir, worktreePath string) error {
 // Remove removes a git worktree. It runs `git worktree remove --force` from
 // the parent repository. The repoDir is the original repository (not the
 // worktree itself).
+//
+// An exclusive filesystem lock is held for the duration of the operation to
+// prevent concurrent worktree operations from corrupting git references.
 func Remove(repoDir, worktreePath string) error {
+	unlock, err := lockRepo(repoDir)
+	if err != nil {
+		return fmt.Errorf("locking repo: %w", err)
+	}
+	defer unlock()
+
 	cmd := exec.Command("git", "worktree", "remove", "--force", worktreePath)
 	cmd.Dir = repoDir
 	var stderr bytes.Buffer

--- a/pkg/worktree/worktree_test.go
+++ b/pkg/worktree/worktree_test.go
@@ -1,10 +1,12 @@
 package worktree
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -148,4 +150,90 @@ func TestCreateMultipleWorktrees(t *testing.T) {
 	if err := Remove(clone, wt2); err != nil {
 		t.Fatalf("Remove(wt2) error: %v", err)
 	}
+}
+
+func TestConcurrentCreate(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	const n = 5
+	wtPaths := make([]string, n)
+	for i := range wtPaths {
+		wtPaths[i] = filepath.Join(t.TempDir(), fmt.Sprintf("wt%d", i))
+	}
+
+	// Create all worktrees concurrently.
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = Create(clone, wtPaths[idx])
+		}(i)
+	}
+	wg.Wait()
+
+	// All creations must succeed.
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Create(wt%d) error: %v", i, err)
+		}
+	}
+
+	// Every worktree must have the README and a valid git remote.
+	for i, wt := range wtPaths {
+		data, err := os.ReadFile(filepath.Join(wt, "README.md"))
+		if err != nil {
+			t.Fatalf("wt%d: missing README: %v", i, err)
+		}
+		if string(data) != "hello" {
+			t.Fatalf("wt%d: unexpected README content: %q", i, data)
+		}
+
+		// Verify git remote is intact.
+		cmd := exec.Command("git", "remote", "-v")
+		cmd.Dir = wt
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("wt%d: git remote -v failed: %v\n%s", i, err, out)
+		}
+		if !strings.Contains(string(out), "origin") {
+			t.Fatalf("wt%d: missing origin remote: %s", i, out)
+		}
+	}
+
+	// Clean up all worktrees.
+	for i, wt := range wtPaths {
+		if err := Remove(clone, wt); err != nil {
+			t.Errorf("Remove(wt%d) error: %v", i, err)
+		}
+	}
+}
+
+func TestLockRepo(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	// Acquire lock.
+	unlock, err := lockRepo(clone)
+	if err != nil {
+		t.Fatalf("lockRepo() error: %v", err)
+	}
+
+	// Verify lock file was created.
+	lockPath := filepath.Join(clone, ".git", "klausctl.lock")
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock file not created: %v", err)
+	}
+
+	// Release lock.
+	unlock()
+
+	// Lock can be acquired again after release.
+	unlock2, err := lockRepo(clone)
+	if err != nil {
+		t.Fatalf("lockRepo() after release error: %v", err)
+	}
+	unlock2()
 }


### PR DESCRIPTION
## Summary

- Adds an exclusive filesystem lock (`flock` on `<repo>/.git/klausctl.lock`) to serialize `Create` and `Remove` worktree operations per source repository
- Prevents concurrent `klausctl create` calls from corrupting git worktree references when targeting the same repo
- Adds concurrent creation test (5 simultaneous worktrees) verifying all produce valid remotes

Closes #91

## What changed

`pkg/worktree/worktree.go`:
- New `lockRepo()` function that acquires an exclusive `flock` on `.git/klausctl.lock` and returns an unlock closure
- `Create()` now holds the lock for the full duration (fetch + branch detection + worktree add)
- `Remove()` also holds the lock to prevent races with concurrent creates

`pkg/worktree/worktree_test.go`:
- `TestConcurrentCreate`: creates 5 worktrees concurrently from the same repo, verifies all have valid content and git remotes
- `TestLockRepo`: verifies lock file creation, release, and re-acquisition

## Self-review summary

**Code reviewer**: No critical blockers. Noted that `syscall.Flock` is Unix-only (acceptable for this project's target platforms) and that the lock file is intentionally left on disk (standard flock pattern).

**Security auditor**: Lock file permissions tightened from `0o644` to `0o600` (least privilege). Error returns in unlock closure made explicitly ignored with `_`. The `--` separator for git path arguments was investigated but reverted since `git worktree add` positional args don't support it and paths are always absolute from `filepath.Join`.

## Test plan

- [x] All existing worktree tests pass (no regression)
- [x] `TestConcurrentCreate` creates 5 worktrees simultaneously, all succeed with valid remotes
- [x] `TestLockRepo` verifies lock lifecycle
- [x] Full test suite passes (pre-existing orchestrator failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)