### PR TITLE
fix: make worktree cleanup resilient with fallback chain

### DIFF
--- a/internal/tools/instance/tools.go
+++ b/internal/tools/instance/tools.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -352,10 +353,12 @@ func handleDelete(ctx context.Context, req mcp.CallToolRequest, sc *server.Serve
 	}
 
 	// Remove git worktree if one was created for this instance.
+	// Worktree cleanup is best-effort: log a warning but don't fail the
+	// overall delete operation so instance state is always cleaned up.
 	cfg, _ := config.Load(paths.ConfigFile)
 	if cfg != nil && cfg.WorktreePath != "" {
 		if err := worktree.Remove(cfg.Workspace, cfg.WorktreePath); err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("removing git worktree: %v", err)), nil
+			log.Printf("Warning: failed to remove git worktree: %v", err)
 		}
 	}
 

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -124,9 +124,11 @@ func Create(repoDir, worktreePath string) error {
 	return nil
 }
 
-// Remove removes a git worktree. It runs `git worktree remove --force` from
-// the parent repository. The repoDir is the original repository (not the
-// worktree itself).
+// Remove removes a git worktree with a resilient fallback chain. It first
+// tries `git worktree remove`, then `git worktree remove --force`, and
+// finally falls back to manual directory removal with `git worktree prune`.
+//
+// The repoDir is the original repository (not the worktree itself).
 //
 // An exclusive filesystem lock is held for the duration of the operation to
 // prevent concurrent worktree operations from corrupting git references.
@@ -137,12 +139,58 @@ func Remove(repoDir, worktreePath string) error {
 	}
 	defer unlock()
 
-	cmd := exec.Command("git", "worktree", "remove", "--force", worktreePath)
+	// Try normal remove.
+	normalErr := gitWorktreeRemove(repoDir, worktreePath, false)
+	if normalErr == nil {
+		return nil
+	}
+
+	// Fall back to force remove.
+	forceErr := gitWorktreeRemove(repoDir, worktreePath, true)
+	if forceErr == nil {
+		return nil
+	}
+
+	// Last resort: remove directory manually and prune stale worktree entries.
+	if err := removeWorktreeManually(repoDir, worktreePath); err != nil {
+		return fmt.Errorf("all removal strategies failed (normal: %v; force: %v; manual: %w)", normalErr, forceErr, err)
+	}
+	return nil
+}
+
+// gitWorktreeRemove runs `git worktree remove` with an optional --force flag.
+func gitWorktreeRemove(repoDir, worktreePath string, force bool) error {
+	args := []string{"worktree", "remove"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, "--", worktreePath)
+
+	cmd := exec.Command("git", args...)
 	cmd.Dir = repoDir
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("git worktree remove %s: %s: %w", worktreePath, strings.TrimSpace(stderr.String()), err)
 	}
+	return nil
+}
+
+// removeWorktreeManually deletes the worktree directory and runs
+// `git worktree prune` to clean up stale references. This is the last-resort
+// fallback when git worktree remove commands fail.
+func removeWorktreeManually(repoDir, worktreePath string) error {
+	if err := os.RemoveAll(worktreePath); err != nil {
+		return fmt.Errorf("removing worktree directory %s: %w", worktreePath, err)
+	}
+
+	cmd := exec.Command("git", "worktree", "prune")
+	cmd.Dir = repoDir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git worktree prune: %s: %w", strings.TrimSpace(stderr.String()), err)
+	}
+
 	return nil
 }

--- a/pkg/worktree/worktree_test.go
+++ b/pkg/worktree/worktree_test.go
@@ -211,6 +211,107 @@ func TestConcurrentCreate(t *testing.T) {
 	}
 }
 
+func TestRemoveFallsBackToForce(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	wtPath := filepath.Join(t.TempDir(), "worktree")
+
+	if err := Create(clone, wtPath); err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	// Modify a tracked file so `git worktree remove` (without --force) fails
+	// due to uncommitted changes.
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("modified"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove should succeed via the --force fallback.
+	if err := Remove(clone, wtPath); err != nil {
+		t.Fatalf("Remove() error: %v", err)
+	}
+
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("expected worktree directory to be removed, stat err: %v", err)
+	}
+}
+
+func TestRemoveFallsBackToManualCleanup(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	wtPath := filepath.Join(t.TempDir(), "worktree")
+
+	if err := Create(clone, wtPath); err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	// Corrupt the worktree by replacing the .git file with garbage.
+	// This makes both `git worktree remove` and `git worktree remove --force`
+	// fail because git cannot validate the worktree.
+	gitFile := filepath.Join(wtPath, ".git")
+	if err := os.Remove(gitFile); err != nil {
+		t.Fatalf("removing .git file: %v", err)
+	}
+	if err := os.WriteFile(gitFile, []byte("garbage"), 0o644); err != nil {
+		t.Fatalf("writing corrupt .git file: %v", err)
+	}
+
+	// Remove should succeed via the manual removal + prune fallback.
+	if err := Remove(clone, wtPath); err != nil {
+		t.Fatalf("Remove() error: %v", err)
+	}
+
+	// Verify the worktree directory is gone.
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("expected worktree directory to be removed, stat err: %v", err)
+	}
+
+	// Verify git no longer lists the worktree.
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = clone
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git worktree list: %v", err)
+	}
+	if strings.Contains(string(out), wtPath) {
+		t.Fatalf("expected worktree to be pruned from git, but still listed:\n%s", out)
+	}
+}
+
+func TestRemoveAlreadyDeletedDirectory(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	wtPath := filepath.Join(t.TempDir(), "worktree")
+
+	if err := Create(clone, wtPath); err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	// Manually delete the worktree directory to simulate partial cleanup.
+	if err := os.RemoveAll(wtPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove should still succeed (manual fallback prunes the stale reference).
+	if err := Remove(clone, wtPath); err != nil {
+		t.Fatalf("Remove() error: %v", err)
+	}
+
+	// Verify git no longer lists the worktree.
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = clone
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git worktree list: %v", err)
+	}
+	if strings.Contains(string(out), wtPath) {
+		t.Fatalf("expected stale worktree to be pruned, but still listed:\n%s", out)
+	}
+}
+
 func TestLockRepo(t *testing.T) {
 	bare := initBareRepo(t)
 	clone := cloneRepo(t, bare)


### PR DESCRIPTION
## Summary

- Adds a three-step fallback chain to `worktree.Remove()`: normal remove → force remove → manual `os.RemoveAll` + `git worktree prune`
- Changes the MCP delete handler to log a warning on worktree removal failure instead of failing the entire operation, matching existing CLI behavior
- Adds `--` separator before path arguments in git commands for defense-in-depth

Closes #92

## Changes

**`pkg/worktree/worktree.go`**
- Refactored `Remove()` to try three escalating cleanup strategies
- Extracted `gitWorktreeRemove()` helper (normal vs force flag)
- Added `removeWorktreeManually()` for last-resort directory deletion + prune
- If all strategies fail, the error wraps context from each failed attempt

**`internal/tools/instance/tools.go`**
- MCP `handleDelete` now logs a warning on worktree removal failure instead of returning an error, so instance state is always cleaned up

**`pkg/worktree/worktree_test.go`**
- `TestRemoveFallsBackToForce` — verifies dirty worktree triggers force fallback
- `TestRemoveFallsBackToManualCleanup` — verifies corrupted worktree triggers manual fallback
- `TestRemoveAlreadyDeletedDirectory` — verifies pre-deleted directory is handled gracefully

## Self-review

**Code review** (base:code-reviewer): Addressed critical finding — errors from all failed strategies are now wrapped in the final error message. Improved test reliability by modifying tracked file (README.md) instead of creating untracked file.

**Security audit** (code-quality:security-auditor): Added `--` argument separator before path in git commands. The `os.RemoveAll` path originates from validated config (absolute path, DNS-label instance name). No command injection risk since `exec.Command` passes args directly without shell.

## Test plan

- [x] All 9 worktree tests pass (3 new fallback tests)
- [x] Full project builds (`go build ./...`)
- [x] All tests pass except pre-existing orchestrator failures (read-only fs, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)