### PR TITLE
fix: parse agent JSON response in result command

### DIFF
--- a/cmd/color.go
+++ b/cmd/color.go
@@ -45,8 +45,10 @@ func bold(s string) string {
 
 func colorStatus(status string) string {
 	switch status {
-	case "started", "completed":
+	case "started", "completed", "idle":
 		return green(status)
+	case "busy":
+		return yellow(status)
 	case "error", "failed":
 		return yellow(status)
 	default:

--- a/cmd/prompt_test.go
+++ b/cmd/prompt_test.go
@@ -133,6 +133,8 @@ func TestColorStatus(t *testing.T) {
 	}{
 		{"started", "started"},
 		{"completed", "completed"},
+		{"idle", "idle"},
+		{"busy", "busy"},
 		{"error", "error"},
 		{"failed", "failed"},
 		{"unknown", "unknown"},

--- a/cmd/result.go
+++ b/cmd/result.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/klausctl/pkg/config"
@@ -37,9 +38,18 @@ func init() {
 }
 
 type resultCLIResult struct {
-	Instance string `json:"instance"`
-	Status   string `json:"status"`
-	Result   string `json:"result,omitempty"`
+	Instance     string `json:"instance"`
+	Status       string `json:"status"`
+	MessageCount int    `json:"message_count"`
+	Result       string `json:"result,omitempty"`
+}
+
+// agentResultResponse represents the JSON payload returned by the agent's
+// result MCP tool. Fields are extracted to populate resultCLIResult.
+type agentResultResponse struct {
+	Status       string `json:"status"`
+	MessageCount int    `json:"message_count"`
+	ResultText   string `json:"result_text"`
 }
 
 func runResult(cmd *cobra.Command, args []string) error {
@@ -90,20 +100,42 @@ func runResult(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("fetching result from %q: %w", instanceName, err)
 	}
 
-	text := extractMCPText(toolResult)
-
-	resultStatus := "completed"
-	if toolResult != nil && toolResult.IsError {
-		resultStatus = "error"
-	}
-
-	result := resultCLIResult{
-		Instance: instanceName,
-		Status:   resultStatus,
-		Result:   text,
-	}
+	result := parseResultResponse(instanceName, toolResult)
 
 	return renderResultOutput(out, result)
+}
+
+// parseResultResponse extracts status, message_count and result_text from the
+// agent's MCP result tool response. The agent returns a JSON payload inside
+// the MCP TextContent; this function parses that payload so the CLI can display
+// accurate status and progress information instead of raw JSON.
+func parseResultResponse(instanceName string, toolResult *mcp.CallToolResult) resultCLIResult {
+	if toolResult != nil && toolResult.IsError {
+		return resultCLIResult{
+			Instance: instanceName,
+			Status:   "error",
+			Result:   extractMCPText(toolResult),
+		}
+	}
+
+	text := extractMCPText(toolResult)
+
+	var parsed agentResultResponse
+	if err := json.Unmarshal([]byte(text), &parsed); err == nil && parsed.Status != "" {
+		return resultCLIResult{
+			Instance:     instanceName,
+			Status:       parsed.Status,
+			MessageCount: parsed.MessageCount,
+			Result:       parsed.ResultText,
+		}
+	}
+
+	// Fallback: response is not the expected JSON structure.
+	return resultCLIResult{
+		Instance: instanceName,
+		Status:   "completed",
+		Result:   text,
+	}
 }
 
 func renderResultOutput(out io.Writer, result resultCLIResult) error {
@@ -115,7 +147,10 @@ func renderResultOutput(out io.Writer, result resultCLIResult) error {
 
 	fmt.Fprintf(out, "Instance: %s\n", result.Instance)
 	fmt.Fprintf(out, "Status:   %s\n", colorStatus(result.Status))
-	if result.Result != "" {
+	fmt.Fprintf(out, "Messages: %d\n", result.MessageCount)
+	if result.Status == "busy" {
+		fmt.Fprintf(out, "\nAgent is still processing the prompt.\nRun 'klausctl result %s' again to check for updates.\n", result.Instance)
+	} else if result.Result != "" {
 		fmt.Fprintf(out, "\n%s\n", result.Result)
 	}
 	return nil

--- a/cmd/result_test.go
+++ b/cmd/result_test.go
@@ -1,0 +1,261 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestParseResultResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  *mcp.CallToolResult
+		wantCLI resultCLIResult
+	}{
+		{
+			name: "completed agent with result text",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{
+						Type: "text",
+						Text: `{"status":"completed","message_count":42,"result_text":"All tests passed."}`,
+					},
+				},
+			},
+			wantCLI: resultCLIResult{
+				Instance:     "dev",
+				Status:       "completed",
+				MessageCount: 42,
+				Result:       "All tests passed.",
+			},
+		},
+		{
+			name: "busy agent with message count",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{
+						Type: "text",
+						Text: `{"status":"busy","message_count":15,"result_text":""}`,
+					},
+				},
+			},
+			wantCLI: resultCLIResult{
+				Instance:     "dev",
+				Status:       "busy",
+				MessageCount: 15,
+				Result:       "",
+			},
+		},
+		{
+			name: "idle agent with zero messages",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{
+						Type: "text",
+						Text: `{"status":"idle","message_count":0,"result_text":""}`,
+					},
+				},
+			},
+			wantCLI: resultCLIResult{
+				Instance:     "dev",
+				Status:       "idle",
+				MessageCount: 0,
+				Result:       "",
+			},
+		},
+		{
+			name: "error from IsError flag",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{Type: "text", Text: "something went wrong"},
+				},
+				IsError: true,
+			},
+			wantCLI: resultCLIResult{
+				Instance: "dev",
+				Status:   "error",
+				Result:   "something went wrong",
+			},
+		},
+		{
+			name: "non-JSON fallback returns completed",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{Type: "text", Text: "plain text result"},
+				},
+			},
+			wantCLI: resultCLIResult{
+				Instance: "dev",
+				Status:   "completed",
+				Result:   "plain text result",
+			},
+		},
+		{
+			name: "JSON without status field falls back to completed",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{Type: "text", Text: `{"other":"field"}`},
+				},
+			},
+			wantCLI: resultCLIResult{
+				Instance: "dev",
+				Status:   "completed",
+				Result:   `{"other":"field"}`,
+			},
+		},
+		{
+			name:   "nil result",
+			result: nil,
+			wantCLI: resultCLIResult{
+				Instance: "dev",
+				Status:   "completed",
+				Result:   "",
+			},
+		},
+		{
+			name: "error status from agent JSON",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{
+						Type: "text",
+						Text: `{"status":"error","message_count":5,"result_text":"Build failed"}`,
+					},
+				},
+			},
+			wantCLI: resultCLIResult{
+				Instance:     "dev",
+				Status:       "error",
+				MessageCount: 5,
+				Result:       "Build failed",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseResultResponse("dev", tt.result)
+			if got.Instance != tt.wantCLI.Instance {
+				t.Errorf("Instance = %q, want %q", got.Instance, tt.wantCLI.Instance)
+			}
+			if got.Status != tt.wantCLI.Status {
+				t.Errorf("Status = %q, want %q", got.Status, tt.wantCLI.Status)
+			}
+			if got.MessageCount != tt.wantCLI.MessageCount {
+				t.Errorf("MessageCount = %d, want %d", got.MessageCount, tt.wantCLI.MessageCount)
+			}
+			if got.Result != tt.wantCLI.Result {
+				t.Errorf("Result = %q, want %q", got.Result, tt.wantCLI.Result)
+			}
+		})
+	}
+}
+
+func TestRenderResultOutput_Text(t *testing.T) {
+	colorEnabled = false
+	t.Cleanup(func() { colorEnabled = detectColor() })
+
+	tests := []struct {
+		name     string
+		result   resultCLIResult
+		contains []string
+	}{
+		{
+			name: "completed with result",
+			result: resultCLIResult{
+				Instance:     "dev",
+				Status:       "completed",
+				MessageCount: 42,
+				Result:       "All tests passed.",
+			},
+			contains: []string{
+				"Instance: dev",
+				"Status:   completed",
+				"Messages: 42",
+				"All tests passed.",
+			},
+		},
+		{
+			name: "busy shows progress hint",
+			result: resultCLIResult{
+				Instance:     "dev",
+				Status:       "busy",
+				MessageCount: 15,
+			},
+			contains: []string{
+				"Instance: dev",
+				"Status:   busy",
+				"Messages: 15",
+				"Agent is still processing",
+				"klausctl result dev",
+			},
+		},
+		{
+			name: "idle with zero messages",
+			result: resultCLIResult{
+				Instance: "dev",
+				Status:   "idle",
+			},
+			contains: []string{
+				"Instance: dev",
+				"Status:   idle",
+				"Messages: 0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resultOutput = "text"
+			var buf bytes.Buffer
+			err := renderResultOutput(&buf, tt.result)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			output := buf.String()
+			for _, want := range tt.contains {
+				if !strings.Contains(output, want) {
+					t.Errorf("output missing %q\ngot:\n%s", want, output)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderResultOutput_JSON(t *testing.T) {
+	resultOutput = "json"
+	t.Cleanup(func() { resultOutput = "text" })
+
+	result := resultCLIResult{
+		Instance:     "dev",
+		Status:       "completed",
+		MessageCount: 42,
+		Result:       "done",
+	}
+
+	var buf bytes.Buffer
+	err := renderResultOutput(&buf, result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var decoded resultCLIResult
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v\ngot:\n%s", err, buf.String())
+	}
+
+	if decoded.Instance != "dev" {
+		t.Errorf("Instance = %q, want %q", decoded.Instance, "dev")
+	}
+	if decoded.Status != "completed" {
+		t.Errorf("Status = %q, want %q", decoded.Status, "completed")
+	}
+	if decoded.MessageCount != 42 {
+		t.Errorf("MessageCount = %d, want %d", decoded.MessageCount, 42)
+	}
+	if decoded.Result != "done" {
+		t.Errorf("Result = %q, want %q", decoded.Result, "done")
+	}
+}

--- a/internal/tools/instance/agent.go
+++ b/internal/tools/instance/agent.go
@@ -88,9 +88,18 @@ func handlePrompt(ctx context.Context, req mcp.CallToolRequest, sc *server.Serve
 }
 
 type agentResult struct {
-	Instance string `json:"instance"`
-	Status   string `json:"status"`
-	Result   string `json:"result,omitempty"`
+	Instance     string `json:"instance"`
+	Status       string `json:"status"`
+	MessageCount int    `json:"message_count"`
+	Result       string `json:"result,omitempty"`
+}
+
+// agentToolResponse represents the JSON payload returned by the agent's
+// result MCP tool inside the container.
+type agentToolResponse struct {
+	Status       string `json:"status"`
+	MessageCount int    `json:"message_count"`
+	ResultText   string `json:"result_text"`
 }
 
 func handleResult(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
@@ -109,16 +118,30 @@ func handleResult(ctx context.Context, req mcp.CallToolRequest, sc *server.Serve
 		return mcp.NewToolResultError(fmt.Sprintf("fetching result from %q: %v", name, err)), nil
 	}
 
-	text := extractText(toolResult)
-
-	status := "completed"
 	if toolResult.IsError {
-		status = "error"
+		return server.JSONResult(agentResult{
+			Instance: name,
+			Status:   "error",
+			Result:   extractText(toolResult),
+		})
 	}
 
+	text := extractText(toolResult)
+
+	var parsed agentToolResponse
+	if err := json.Unmarshal([]byte(text), &parsed); err == nil && parsed.Status != "" {
+		return server.JSONResult(agentResult{
+			Instance:     name,
+			Status:       parsed.Status,
+			MessageCount: parsed.MessageCount,
+			Result:       parsed.ResultText,
+		})
+	}
+
+	// Fallback: response is not the expected JSON structure.
 	return server.JSONResult(agentResult{
 		Instance: name,
-		Status:   status,
+		Status:   "completed",
 		Result:   text,
 	})
 }

--- a/internal/tools/instance/agent_test.go
+++ b/internal/tools/instance/agent_test.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -149,6 +150,55 @@ func TestTerminalStatuses(t *testing.T) {
 		if terminalStatuses[status] {
 			t.Errorf("expected %q to NOT be terminal", status)
 		}
+	}
+}
+
+func TestParseAgentToolResponse(t *testing.T) {
+	tests := []struct {
+		name             string
+		text             string
+		wantStatus       string
+		wantMessageCount int
+		wantResult       string
+	}{
+		{
+			name:             "completed with result",
+			text:             `{"status":"completed","message_count":42,"result_text":"All tests passed."}`,
+			wantStatus:       "completed",
+			wantMessageCount: 42,
+			wantResult:       "All tests passed.",
+		},
+		{
+			name:             "busy agent",
+			text:             `{"status":"busy","message_count":15,"result_text":""}`,
+			wantStatus:       "busy",
+			wantMessageCount: 15,
+			wantResult:       "",
+		},
+		{
+			name:             "idle agent",
+			text:             `{"status":"idle","message_count":0,"result_text":""}`,
+			wantStatus:       "idle",
+			wantMessageCount: 0,
+			wantResult:       "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resp agentToolResponse
+			if err := json.Unmarshal([]byte(tt.text), &resp); err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			if resp.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", resp.Status, tt.wantStatus)
+			}
+			if resp.MessageCount != tt.wantMessageCount {
+				t.Errorf("MessageCount = %d, want %d", resp.MessageCount, tt.wantMessageCount)
+			}
+			if resp.ResultText != tt.wantResult {
+				t.Errorf("ResultText = %q, want %q", resp.ResultText, tt.wantResult)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Parse the JSON response from the agent's MCP result tool to extract `status`, `message_count`, and `result_text` fields instead of hardcoding status as "completed"
- Display accurate agent status (busy/idle/completed/error) with message count in both text and JSON output modes
- Show progress hint when agent is busy (suggests re-running `klausctl result`)
- Format output as human-readable text by default, extracting `result_text` from JSON instead of dumping raw JSON
- Apply the same parsing fix to the MCP tool handler (`handleResult`) so MCP clients also get accurate data

Closes #79

## Test plan

- [x] Added unit tests for `parseResultResponse` covering: completed, busy, idle, error, non-JSON fallback, nil result
- [x] Added unit tests for `renderResultOutput` in both text and JSON modes
- [x] Added unit tests for `agentToolResponse` JSON parsing on the MCP handler side
- [x] Updated `colorStatus` tests for new busy/idle statuses
- [x] All existing tests pass

## Self-review

**Code review** (`base:code-reviewer`): No critical issues in new code. Warnings about pre-existing patterns (package-level global state for output format, duplicate response structs across CLI and server packages). Changes are consistent with existing conventions.

**Security audit** (`code-quality:security-auditor`): No critical or high findings. Low-severity notes: no payload size limit on JSON unmarshal (mitigated by agent being user-controlled infrastructure), unvalidated status string values (mitigated by terminal-only output context). Safe deserialization into typed Go structs with graceful fallback on parse failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)