### PR TITLE
feat: render structured YAML config file for containers

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -46,7 +46,9 @@ func BuildRunOptions(cfg *config.Config, paths *config.Paths, containerName, ima
 }
 
 // BuildEnvVars constructs all container environment variables from config.
-// These mirror the Helm deployment.yaml env section.
+// Claude, Git, and Agent settings are now rendered into the container config
+// YAML file (see renderer.BuildContainerConfig). This function only sets
+// env vars for secrets, forwarded vars, and the config file path.
 func BuildEnvVars(cfg *config.Config, paths *config.Paths) (map[string]string, error) {
 	env := make(map[string]string)
 
@@ -83,6 +85,9 @@ func BuildEnvVars(cfg *config.Config, paths *config.Paths) (map[string]string, e
 		}
 	}
 
+	// Git and Claude settings are now in the container config YAML.
+	// Keep env vars as fallback for backward compatibility with older
+	// container images that don't yet read the config file.
 	setGitEnvVars(env, &cfg.Git)
 	setClaudeEnvVars(env, &cfg.Claude)
 
@@ -160,6 +165,16 @@ func BuildVolumes(cfg *config.Config, paths *config.Paths, env map[string]string
 		ContainerPath: "/workspace",
 	})
 	env["CLAUDE_WORKSPACE"] = "/workspace"
+
+	// Mount the rendered container config YAML. The container reads this
+	// instead of relying on 30+ individual environment variables.
+	configPath := filepath.Join(paths.RenderedDir, "config.yaml")
+	vols = append(vols, runtime.Volume{
+		HostPath:      configPath,
+		ContainerPath: "/etc/klaus/config.yaml",
+		ReadOnly:      true,
+	})
+	env["KLAUS_CONFIG_FILE"] = "/etc/klaus/config.yaml"
 
 	if len(cfg.McpServers) > 0 {
 		mcpConfigPath := filepath.Join(paths.RenderedDir, "mcp-config.json")

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -170,6 +170,37 @@ func TestBuildVolumes_WorkspaceMount(t *testing.T) {
 	}
 }
 
+func TestBuildVolumes_ContainerConfigMount(t *testing.T) {
+	cfg := &config.Config{Workspace: t.TempDir()}
+	paths := testPaths(t)
+	env := make(map[string]string)
+
+	vols, err := BuildVolumes(cfg, paths, env, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, v := range vols {
+		if v.ContainerPath == "/etc/klaus/config.yaml" {
+			found = true
+			if !v.ReadOnly {
+				t.Error("expected config mount to be read-only")
+			}
+			expectedHost := filepath.Join(paths.RenderedDir, "config.yaml")
+			if v.HostPath != expectedHost {
+				t.Errorf("host path = %q, want %q", v.HostPath, expectedHost)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected /etc/klaus/config.yaml volume mount")
+	}
+	if env["KLAUS_CONFIG_FILE"] != "/etc/klaus/config.yaml" {
+		t.Errorf("KLAUS_CONFIG_FILE = %q, want /etc/klaus/config.yaml", env["KLAUS_CONFIG_FILE"])
+	}
+}
+
 func TestBuildVolumes_McpConfigMount(t *testing.T) {
 	cfg := &config.Config{
 		Workspace:  t.TempDir(),

--- a/pkg/renderer/config.go
+++ b/pkg/renderer/config.go
@@ -1,0 +1,115 @@
+package renderer
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+)
+
+// ContainerClaudeConfig contains the Claude Code settings that the container
+// process needs. This is an explicit projection of config.ClaudeConfig that
+// excludes host-side orchestration fields (SettingsFile, AddDirs, PluginDirs,
+// LoadAdditionalDirsMemory) which are handled by the orchestrator via volume
+// mounts and env vars.
+type ContainerClaudeConfig struct {
+	Model                  string   `yaml:"model,omitempty"`
+	SystemPrompt           string   `yaml:"systemPrompt,omitempty"`
+	AppendSystemPrompt     string   `yaml:"appendSystemPrompt,omitempty"`
+	MaxTurns               int      `yaml:"maxTurns,omitempty"`
+	PermissionMode         string   `yaml:"permissionMode,omitempty"`
+	MaxBudgetUSD           float64  `yaml:"maxBudgetUsd,omitempty"`
+	Effort                 string   `yaml:"effort,omitempty"`
+	FallbackModel          string   `yaml:"fallbackModel,omitempty"`
+	Tools                  []string `yaml:"tools,omitempty"`
+	AllowedTools           []string `yaml:"allowedTools,omitempty"`
+	DisallowedTools        []string `yaml:"disallowedTools,omitempty"`
+	StrictMcpConfig        bool     `yaml:"strictMcpConfig,omitempty"`
+	McpTimeout             int      `yaml:"mcpTimeout,omitempty"`
+	MaxMcpOutputTokens     int      `yaml:"maxMcpOutputTokens,omitempty"`
+	ActiveAgent            string   `yaml:"activeAgent,omitempty"`
+	PersistentMode         bool     `yaml:"persistentMode,omitempty"`
+	NoSessionPersistence   *bool    `yaml:"noSessionPersistence,omitempty"`
+	IncludePartialMessages bool     `yaml:"includePartialMessages,omitempty"`
+	JsonSchema             string   `yaml:"jsonSchema,omitempty"`
+	SettingSources         string   `yaml:"settingSources,omitempty"`
+}
+
+// ContainerGitConfig contains the git identity settings for the container.
+// Host-side fields (CredentialHelper, HTTPSInsteadOfSSH) are excluded because
+// the orchestrator handles them via a generated gitconfig volume mount.
+type ContainerGitConfig struct {
+	AuthorName  string `yaml:"authorName,omitempty"`
+	AuthorEmail string `yaml:"authorEmail,omitempty"`
+}
+
+// ContainerConfig is the YAML configuration rendered for the klaus container.
+// It contains only the fields that the container process needs, replacing 30+
+// individual environment variables with a single structured file. Fields that
+// drive host-side orchestration (volume mounts, env var assembly) are excluded.
+type ContainerConfig struct {
+	Workspace string                        `yaml:"workspace"`
+	Port      int                           `yaml:"port"`
+	Claude    ContainerClaudeConfig         `yaml:"claude,omitempty"`
+	Git       ContainerGitConfig            `yaml:"git,omitempty"`
+	Agents    map[string]config.AgentConfig `yaml:"agents,omitempty"`
+}
+
+// BuildContainerConfig constructs the container-side config from the full
+// klausctl Config. Workspace is always "/workspace" and Port is always 8080
+// because these are the fixed container-internal values regardless of the
+// host-side configuration.
+func BuildContainerConfig(cfg *config.Config) *ContainerConfig {
+	cc := &ContainerConfig{
+		Workspace: "/workspace",
+		Port:      8080,
+		Claude: ContainerClaudeConfig{
+			Model:                  cfg.Claude.Model,
+			SystemPrompt:           cfg.Claude.SystemPrompt,
+			AppendSystemPrompt:     cfg.Claude.AppendSystemPrompt,
+			MaxTurns:               cfg.Claude.MaxTurns,
+			PermissionMode:         cfg.Claude.PermissionMode,
+			MaxBudgetUSD:           cfg.Claude.MaxBudgetUSD,
+			Effort:                 cfg.Claude.Effort,
+			FallbackModel:          cfg.Claude.FallbackModel,
+			Tools:                  cfg.Claude.Tools,
+			AllowedTools:           cfg.Claude.AllowedTools,
+			DisallowedTools:        cfg.Claude.DisallowedTools,
+			StrictMcpConfig:        cfg.Claude.StrictMcpConfig,
+			McpTimeout:             cfg.Claude.McpTimeout,
+			MaxMcpOutputTokens:     cfg.Claude.MaxMcpOutputTokens,
+			ActiveAgent:            cfg.Claude.ActiveAgent,
+			PersistentMode:         cfg.Claude.PersistentMode,
+			NoSessionPersistence:   cfg.Claude.NoSessionPersistence,
+			IncludePartialMessages: cfg.Claude.IncludePartialMessages,
+			JsonSchema:             cfg.Claude.JsonSchema,
+			SettingSources:         cfg.Claude.SettingSources,
+		},
+		Git: ContainerGitConfig{
+			AuthorName:  cfg.Git.AuthorName,
+			AuthorEmail: cfg.Git.AuthorEmail,
+		},
+	}
+
+	if len(cfg.Agents) > 0 {
+		cc.Agents = cfg.Agents
+	}
+
+	return cc
+}
+
+// renderContainerConfig writes the container config YAML file to the rendered
+// directory. The container reads this file via the KLAUS_CONFIG_FILE env var.
+func (r *Renderer) renderContainerConfig(cfg *config.Config) error {
+	cc := BuildContainerConfig(cfg)
+
+	data, err := yaml.Marshal(cc)
+	if err != nil {
+		return fmt.Errorf("marshaling container config: %w", err)
+	}
+
+	path := filepath.Join(r.paths.RenderedDir, "config.yaml")
+	return writeFile(path, data, 0o600)
+}

--- a/pkg/renderer/config_test.go
+++ b/pkg/renderer/config_test.go
@@ -1,0 +1,320 @@
+package renderer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+)
+
+func TestBuildContainerConfig_FixedContainerValues(t *testing.T) {
+	cfg := &config.Config{
+		Workspace: "/home/user/project",
+		Port:      9090,
+	}
+
+	cc := BuildContainerConfig(cfg)
+
+	// Workspace and Port are always the container-internal values,
+	// regardless of what the host config specifies.
+	if cc.Workspace != "/workspace" {
+		t.Errorf("Workspace = %q, want /workspace", cc.Workspace)
+	}
+	if cc.Port != 8080 {
+		t.Errorf("Port = %d, want 8080", cc.Port)
+	}
+}
+
+func TestBuildContainerConfig_ClaudeSettings(t *testing.T) {
+	noSess := true
+	cfg := &config.Config{
+		Workspace: "/tmp/ws",
+		Port:      8080,
+		Claude: config.ClaudeConfig{
+			Model:                "opus",
+			SystemPrompt:         "You are helpful.",
+			AppendSystemPrompt:   "Be concise.",
+			PermissionMode:       "bypassPermissions",
+			Effort:               "high",
+			FallbackModel:        "sonnet",
+			MaxTurns:             50,
+			MaxBudgetUSD:         10.0,
+			StrictMcpConfig:      true,
+			McpTimeout:           30000,
+			MaxMcpOutputTokens:   8192,
+			ActiveAgent:          "reviewer",
+			PersistentMode:       true,
+			NoSessionPersistence: &noSess,
+			Tools:                []string{"read", "write"},
+			AllowedTools:         []string{"mcp__*"},
+			DisallowedTools:      []string{"bash"},
+		},
+	}
+
+	cc := BuildContainerConfig(cfg)
+
+	if cc.Claude.Model != "opus" {
+		t.Errorf("Claude.Model = %q, want opus", cc.Claude.Model)
+	}
+	if cc.Claude.SystemPrompt != "You are helpful." {
+		t.Errorf("Claude.SystemPrompt = %q", cc.Claude.SystemPrompt)
+	}
+	if cc.Claude.PermissionMode != "bypassPermissions" {
+		t.Errorf("Claude.PermissionMode = %q", cc.Claude.PermissionMode)
+	}
+	if cc.Claude.MaxTurns != 50 {
+		t.Errorf("Claude.MaxTurns = %d, want 50", cc.Claude.MaxTurns)
+	}
+	if cc.Claude.MaxBudgetUSD != 10.0 {
+		t.Errorf("Claude.MaxBudgetUSD = %f, want 10.0", cc.Claude.MaxBudgetUSD)
+	}
+	if !cc.Claude.StrictMcpConfig {
+		t.Error("Claude.StrictMcpConfig should be true")
+	}
+	if len(cc.Claude.Tools) != 2 {
+		t.Errorf("Claude.Tools length = %d, want 2", len(cc.Claude.Tools))
+	}
+	if !cc.Claude.PersistentMode {
+		t.Error("Claude.PersistentMode should be true")
+	}
+	if cc.Claude.NoSessionPersistence == nil || !*cc.Claude.NoSessionPersistence {
+		t.Error("Claude.NoSessionPersistence should be true")
+	}
+}
+
+func TestBuildContainerConfig_ExcludesHostFields(t *testing.T) {
+	cfg := &config.Config{
+		Workspace: "/tmp/ws",
+		Port:      8080,
+		Claude: config.ClaudeConfig{
+			Model:        "sonnet",
+			SettingsFile: "/host/path/settings.json",
+			AddDirs:      []string{"/host/extra"},
+			PluginDirs:   []string{"/host/plugins"},
+		},
+		Git: config.GitConfig{
+			AuthorName:        "Test",
+			AuthorEmail:       "test@example.com",
+			CredentialHelper:  "gh",
+			HTTPSInsteadOfSSH: true,
+		},
+	}
+
+	cc := BuildContainerConfig(cfg)
+
+	// Verify the container config YAML doesn't contain host-only fields.
+	data, err := yaml.Marshal(cc)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	content := string(data)
+
+	// Host-only ClaudeConfig fields should not appear.
+	for _, excluded := range []string{"settingsFile", "addDirs", "pluginDirs"} {
+		if contains(content, excluded) {
+			t.Errorf("container config should not contain %q (host-only field)", excluded)
+		}
+	}
+
+	// Host-only GitConfig fields should not appear.
+	for _, excluded := range []string{"credentialHelper", "httpsInsteadOfSsh"} {
+		if contains(content, excluded) {
+			t.Errorf("container config should not contain %q (host-only field)", excluded)
+		}
+	}
+
+	// Container-relevant fields should still be present.
+	if cc.Claude.Model != "sonnet" {
+		t.Errorf("Claude.Model = %q, want sonnet", cc.Claude.Model)
+	}
+	if cc.Git.AuthorName != "Test" {
+		t.Errorf("Git.AuthorName = %q, want Test", cc.Git.AuthorName)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && len(s) >= len(substr) && stringContains(s, substr)
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildContainerConfig_GitSettings(t *testing.T) {
+	cfg := &config.Config{
+		Workspace: "/tmp/ws",
+		Port:      8080,
+		Git: config.GitConfig{
+			AuthorName:  "Klaus Agent",
+			AuthorEmail: "klaus@example.com",
+		},
+	}
+
+	cc := BuildContainerConfig(cfg)
+
+	if cc.Git.AuthorName != "Klaus Agent" {
+		t.Errorf("Git.AuthorName = %q", cc.Git.AuthorName)
+	}
+	if cc.Git.AuthorEmail != "klaus@example.com" {
+		t.Errorf("Git.AuthorEmail = %q", cc.Git.AuthorEmail)
+	}
+}
+
+func TestBuildContainerConfig_Agents(t *testing.T) {
+	cfg := &config.Config{
+		Workspace: "/tmp/ws",
+		Port:      8080,
+		Agents: map[string]config.AgentConfig{
+			"reviewer": {
+				Description: "Code reviewer",
+				Prompt:      "Review this code.",
+				Model:       "sonnet",
+			},
+		},
+	}
+
+	cc := BuildContainerConfig(cfg)
+
+	if len(cc.Agents) != 1 {
+		t.Fatalf("Agents length = %d, want 1", len(cc.Agents))
+	}
+	if cc.Agents["reviewer"].Description != "Code reviewer" {
+		t.Errorf("Agents[reviewer].Description = %q", cc.Agents["reviewer"].Description)
+	}
+}
+
+func TestBuildContainerConfig_NoAgentsWhenEmpty(t *testing.T) {
+	cfg := &config.Config{
+		Workspace: "/tmp/ws",
+		Port:      8080,
+	}
+
+	cc := BuildContainerConfig(cfg)
+
+	if cc.Agents != nil {
+		t.Error("Agents should be nil when no agents configured")
+	}
+}
+
+func TestRenderContainerConfig(t *testing.T) {
+	paths := testPaths(t)
+	r := New(paths)
+
+	cfg := &config.Config{
+		Workspace: "/home/user/project",
+		Port:      9090,
+		Claude: config.ClaudeConfig{
+			Model:          "sonnet",
+			PermissionMode: "bypassPermissions",
+			MaxTurns:       25,
+		},
+		Git: config.GitConfig{
+			AuthorName:  "Test User",
+			AuthorEmail: "test@example.com",
+		},
+	}
+
+	if err := r.Render(cfg); err != nil {
+		t.Fatalf("Render() returned error: %v", err)
+	}
+
+	configPath := filepath.Join(paths.RenderedDir, "config.yaml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("config.yaml not created: %v", err)
+	}
+
+	// Verify it's valid YAML.
+	var cc ContainerConfig
+	if err := yaml.Unmarshal(data, &cc); err != nil {
+		t.Fatalf("invalid YAML: %v", err)
+	}
+
+	// Container workspace is always /workspace regardless of host path.
+	if cc.Workspace != "/workspace" {
+		t.Errorf("Workspace = %q, want /workspace", cc.Workspace)
+	}
+	// Container port is always 8080.
+	if cc.Port != 8080 {
+		t.Errorf("Port = %d, want 8080", cc.Port)
+	}
+	if cc.Claude.Model != "sonnet" {
+		t.Errorf("Claude.Model = %q, want sonnet", cc.Claude.Model)
+	}
+	if cc.Claude.MaxTurns != 25 {
+		t.Errorf("Claude.MaxTurns = %d, want 25", cc.Claude.MaxTurns)
+	}
+	if cc.Git.AuthorName != "Test User" {
+		t.Errorf("Git.AuthorName = %q, want Test User", cc.Git.AuthorName)
+	}
+
+	// Verify file permissions are restrictive.
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config.yaml: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("config.yaml permissions = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestRenderContainerConfig_MarshalRoundTrip(t *testing.T) {
+	noSess := false
+	cfg := &config.Config{
+		Workspace: "/tmp",
+		Port:      8080,
+		Claude: config.ClaudeConfig{
+			Model:                  "opus",
+			Effort:                 "high",
+			IncludePartialMessages: true,
+			NoSessionPersistence:   &noSess,
+			JsonSchema:             `{"type":"object"}`,
+		},
+		Agents: map[string]config.AgentConfig{
+			"helper": {
+				Description: "A helper agent",
+				Prompt:      "Help the user.",
+				Tools:       []string{"read", "write"},
+			},
+		},
+	}
+
+	cc := BuildContainerConfig(cfg)
+	data, err := yaml.Marshal(cc)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var roundTripped ContainerConfig
+	if err := yaml.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if roundTripped.Claude.Model != "opus" {
+		t.Errorf("Model = %q after round-trip", roundTripped.Claude.Model)
+	}
+	if roundTripped.Claude.Effort != "high" {
+		t.Errorf("Effort = %q after round-trip", roundTripped.Claude.Effort)
+	}
+	if !roundTripped.Claude.IncludePartialMessages {
+		t.Error("IncludePartialMessages should be true after round-trip")
+	}
+	// Verify *bool pointer survives round-trip with false value.
+	if roundTripped.Claude.NoSessionPersistence == nil {
+		t.Fatal("NoSessionPersistence should not be nil after round-trip")
+	}
+	if *roundTripped.Claude.NoSessionPersistence {
+		t.Error("NoSessionPersistence should be false after round-trip")
+	}
+	if len(roundTripped.Agents) != 1 {
+		t.Errorf("Agents length = %d after round-trip", len(roundTripped.Agents))
+	}
+}

--- a/pkg/renderer/renderer.go
+++ b/pkg/renderer/renderer.go
@@ -33,6 +33,11 @@ func (r *Renderer) Render(cfg *config.Config) error {
 		return fmt.Errorf("creating rendered directory: %w", err)
 	}
 
+	// Render container config YAML (replaces most env vars).
+	if err := r.renderContainerConfig(cfg); err != nil {
+		return fmt.Errorf("rendering container config: %w", err)
+	}
+
 	// Render skills.
 	if len(cfg.Skills) > 0 {
 		if err := r.renderSkills(cfg.Skills); err != nil {


### PR DESCRIPTION
## Summary

Renders a structured YAML config file (`config.yaml`) for klaus containers instead of relying solely on 30+ environment variables. The config file is mounted at `/etc/klaus/config.yaml` (read-only) with `KLAUS_CONFIG_FILE` env var pointing to it. Env vars are kept as backward-compatible fallback for older container images.

Closes #95

## Changes

- **`pkg/renderer/config.go`** -- `ContainerConfig`, `ContainerClaudeConfig`, `ContainerGitConfig` types with explicit field projection (excludes host-only fields to prevent path leakage). `BuildContainerConfig()` constructs config with fixed container-internal values. 0600 file permissions.
- **`pkg/renderer/config_test.go`** -- 8 test functions covering fixed values, field projection, host exclusion, Git settings, agents, render integration, and YAML round-trip.
- **`pkg/renderer/renderer.go`** -- Added `renderContainerConfig()` to `Render()` pipeline.
- **`pkg/orchestrator/orchestrator.go`** -- Mounts `config.yaml` at `/etc/klaus/config.yaml` read-only, sets `KLAUS_CONFIG_FILE` env var.
- **`pkg/orchestrator/orchestrator_test.go`** -- Volume mount verification test.

## Test plan

- [ ] Unit tests pass (`go test ./...`)
- [ ] Config file is mounted correctly in container
- [ ] Container reads config from YAML file
- [ ] Backward compat: env vars still work for older images

Made with [Cursor](https://cursor.com)