### PR TITLE
feat: check host port availability before auto-selection

### DIFF
--- a/pkg/config/generate.go
+++ b/pkg/config/generate.go
@@ -232,9 +232,11 @@ func applyCreateOverrides(cfg *Config, opts CreateOptions) {
 	}
 }
 
-// IsPortAvailable checks whether a TCP port is free on the host by attempting
-// a brief bind on all interfaces. It works on both Linux and macOS without
-// relying on external tools.
+// IsPortAvailable probes whether a TCP port appears to be free on the host at
+// the moment of the call by attempting a brief bind on all interfaces. Because
+// the socket is closed before returning, the result is a best-effort snapshot:
+// the port may be claimed by another process between this check and the actual
+// daemon bind. Works on Linux and macOS without relying on external tools.
 func IsPortAvailable(port int) bool {
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {

--- a/pkg/config/generate_test.go
+++ b/pkg/config/generate_test.go
@@ -154,8 +154,8 @@ func TestNextAvailablePort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NextAvailablePort() returned error: %v", err)
 	}
-	if port != 8081 {
-		t.Fatalf("NextAvailablePort() = %d, want 8081", port)
+	if port <= 8080 {
+		t.Fatalf("NextAvailablePort() = %d, want > 8080 (8080 is used by another instance)", port)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Auto-selected ports now skip ports already in use on the host by attempting a brief TCP bind before assignment
- Explicit `--port` fails with a clear error ("port N is already in use on the host") if the port is occupied, without silent fallback
- The `IsPortAvailable` check uses `net.Listen` which works cross-platform (Linux and macOS) without external tools

Closes #104

## Self-review

- Reviewed by `base:code-reviewer`: addressed the doc comment TOCTOU clarification and test flakiness warning
- Reviewed by `code-quality:security-auditor`: no critical/high findings; low-severity TOCTOU inherent to probe-then-use pattern is documented

## Test plan

- [x] `TestIsPortAvailable_FreePort` — verifies a recently-freed port is detected as available
- [x] `TestIsPortAvailable_OccupiedPort` — verifies an actively-listened port is detected as unavailable
- [x] `TestNextAvailablePort_SkipsHostOccupied` — verifies auto-selection skips host-occupied ports
- [x] `TestGenerateInstanceConfig_ExplicitPortHostOccupied` — verifies explicit `--port` returns clear error for occupied port
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)