### PR TITLE
feat: add klausctl run command and klaus_run MCP tool

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,356 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/instance"
+	"github.com/giantswarm/klausctl/pkg/mcpclient"
+	"github.com/giantswarm/klausctl/pkg/orchestrator"
+	"github.com/giantswarm/klausctl/pkg/worktree"
+)
+
+var (
+	runPersonality       string
+	runToolchain         string
+	runPlugins           []string
+	runPort              int
+	runEnv               []string
+	runEnvForward        []string
+	runSecretEnv         []string
+	runSecretFile        []string
+	runMcpServer         []string
+	runPermMode          string
+	runModel             string
+	runSystemPrompt      string
+	runMaxBudget         float64
+	runSource            string
+	runNoIsolate         bool
+	runGitAuthor         string
+	runGitCredHelper     string
+	runGitHTTPSInsteadOf bool
+
+	runMessage  string
+	runBlocking bool
+	runOutput   string
+)
+
+var runCmd = &cobra.Command{
+	Use:   "run <name> [workspace]",
+	Short: "Create an instance and send a prompt in one step",
+	Long: `Create a new klaus instance, wait for it to become ready, and send a
+prompt — all in a single command.
+
+This combines 'klausctl create' and 'klausctl prompt' into one operation,
+reducing boilerplate in agent workflows. All flags from 'create' are
+supported, plus -m/--message to supply the prompt.
+
+By default the command returns once the prompt is accepted. Use --blocking
+to wait for the agent to finish and print the result.
+
+Examples:
+
+  klausctl run dev ~/myproject -m "Fix the failing tests"
+  klausctl run dev ~/myproject --personality go -m "List all TODO comments" --blocking
+  klausctl run dev -m "Refactor the handler" --blocking -o json`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runRun,
+}
+
+func init() {
+	runCmd.Flags().StringVar(&runPersonality, "personality", "", "personality short name or OCI reference")
+	runCmd.Flags().StringVar(&runToolchain, "toolchain", "", "toolchain short name or OCI reference")
+	runCmd.Flags().StringSliceVar(&runPlugins, "plugin", nil, "additional plugin short name or OCI reference (repeatable)")
+	runCmd.Flags().IntVar(&runPort, "port", 0, "override auto-selected port")
+	runCmd.Flags().StringArrayVar(&runEnv, "env", nil, "environment variable KEY=VALUE (repeatable)")
+	runCmd.Flags().StringArrayVar(&runEnvForward, "env-forward", nil, "host environment variable name to forward (repeatable)")
+	runCmd.Flags().StringVar(&runPermMode, "permission-mode", "", "Claude permission mode: default, acceptEdits, bypassPermissions, dontAsk, plan, delegate")
+	runCmd.Flags().StringVar(&runModel, "model", "", "Claude model (e.g. sonnet, opus)")
+	runCmd.Flags().StringVar(&runSystemPrompt, "system-prompt", "", "system prompt override for the Claude agent")
+	runCmd.Flags().Float64Var(&runMaxBudget, "max-budget", 0, "maximum dollar budget per invocation (0 = no limit)")
+	runCmd.Flags().StringArrayVar(&runSecretEnv, "secret-env", nil, "secret env var ENV_NAME=secret-name (repeatable)")
+	runCmd.Flags().StringArrayVar(&runSecretFile, "secret-file", nil, "secret file /container/path=secret-name (repeatable)")
+	runCmd.Flags().StringArrayVar(&runMcpServer, "mcpserver", nil, "managed MCP server name (repeatable)")
+	runCmd.Flags().StringVar(&runSource, "source", "", "resolve artifact short names against a specific source")
+	runCmd.Flags().BoolVar(&runNoIsolate, "no-isolate", false, "skip git worktree creation and bind-mount workspace directly")
+	runCmd.Flags().StringVar(&runGitAuthor, "git-author", "", `git author identity "Name <email>"`)
+	runCmd.Flags().StringVar(&runGitCredHelper, "git-credential-helper", "", "git credential helper (currently only 'gh')")
+	runCmd.Flags().BoolVar(&runGitHTTPSInsteadOf, "git-https-instead-of-ssh", false, "rewrite SSH git URLs to HTTPS via container-local gitconfig")
+
+	runCmd.Flags().StringVarP(&runMessage, "message", "m", "", "prompt message to send to the agent (required)")
+	runCmd.Flags().BoolVar(&runBlocking, "blocking", false, "wait for the agent to complete and return the result")
+	runCmd.Flags().StringVarP(&runOutput, "output", "o", "text", "output format: text, json")
+	_ = runCmd.MarkFlagRequired("message")
+	rootCmd.AddCommand(runCmd)
+}
+
+func runRun(cmd *cobra.Command, args []string) (retErr error) {
+	instanceName := args[0]
+	if err := config.ValidateInstanceName(instanceName); err != nil {
+		return err
+	}
+
+	workspace := ""
+	if len(args) > 1 {
+		workspace = args[1]
+	} else {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("determining current directory: %w", err)
+		}
+		workspace = cwd
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	out := cmd.OutOrStdout()
+
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+	if err := config.MigrateLayout(paths); err != nil {
+		return fmt.Errorf("migrating config layout: %w", err)
+	}
+
+	instancePaths := paths.ForInstance(instanceName)
+	if _, err := os.Stat(instancePaths.InstanceDir); err == nil {
+		return fmt.Errorf("instance %q already exists", instanceName)
+	}
+
+	resolver, err := buildSourceResolver(runSource)
+	if err != nil {
+		return err
+	}
+
+	if runSource != "" {
+		fmt.Fprintf(out, "Using source %q for artifact resolution\n", runSource)
+	}
+
+	personality, toolchain, plugins, err := orchestrator.ResolveCreateRefs(ctx, resolver, runPersonality, runToolchain, runPlugins)
+	if err != nil {
+		return err
+	}
+
+	envVars, err := parseEnvFlags(runEnv)
+	if err != nil {
+		return err
+	}
+
+	secretEnvVars, err := parseEnvFlags(runSecretEnv)
+	if err != nil {
+		return fmt.Errorf("parsing --secret-env: %w", err)
+	}
+
+	secretFiles, err := parseEnvFlags(runSecretFile)
+	if err != nil {
+		return fmt.Errorf("parsing --secret-file: %w", err)
+	}
+
+	if runPort < 0 || runPort > 65535 {
+		return fmt.Errorf("port must be between 0 and 65535, got %d", runPort)
+	}
+
+	gitName, gitEmail, err := parseGitAuthor(runGitAuthor)
+	if err != nil {
+		return err
+	}
+
+	opts := config.CreateOptions{
+		Name:                 instanceName,
+		Workspace:            workspace,
+		NoIsolate:            runNoIsolate,
+		Personality:          personality,
+		Toolchain:            toolchain,
+		Plugins:              plugins,
+		Port:                 runPort,
+		GitAuthorName:        gitName,
+		GitAuthorEmail:       gitEmail,
+		GitCredentialHelper:  runGitCredHelper,
+		GitHTTPSInsteadOfSSH: runGitHTTPSInsteadOf,
+		EnvVars:              envVars,
+		EnvForward:           runEnvForward,
+		SecretEnvVars:        secretEnvVars,
+		SecretFiles:          secretFiles,
+		McpServerRefs:        runMcpServer,
+		PermissionMode:       runPermMode,
+		Model:                runModel,
+		SystemPrompt:         runSystemPrompt,
+		SourceResolver:       resolver,
+		Context:              ctx,
+		Output:               out,
+		ResolvePersonality: func(ctx context.Context, ref string, outWriter io.Writer) (*config.ResolvedPersonality, error) {
+			if err := config.EnsureDir(paths.PersonalitiesDir); err != nil {
+				return nil, fmt.Errorf("creating personalities directory: %w", err)
+			}
+			client := orchestrator.NewDefaultClient()
+			pr, err := orchestrator.ResolvePersonality(ctx, client, ref, paths.PersonalitiesDir, outWriter)
+			if err != nil {
+				return nil, err
+			}
+
+			plugins, err := orchestrator.ResolvePluginRefs(ctx, client, pr.Spec.Plugins)
+			if err != nil {
+				return nil, fmt.Errorf("resolving personality plugins: %w", err)
+			}
+
+			image, err := client.ResolveToolchainRef(ctx, pr.Spec.Toolchain.Ref())
+			if err != nil {
+				return nil, fmt.Errorf("resolving personality image: %w", err)
+			}
+
+			return &config.ResolvedPersonality{
+				Plugins: plugins,
+				Image:   image,
+			}, nil
+		},
+	}
+	if cmd.Flags().Changed("max-budget") {
+		opts.MaxBudgetUSD = &runMaxBudget
+	}
+
+	cfg, err := config.GenerateInstanceConfig(paths, opts)
+	if err != nil {
+		return err
+	}
+
+	if err := config.EnsureDir(instancePaths.InstanceDir); err != nil {
+		return fmt.Errorf("creating instance directory: %w", err)
+	}
+
+	defer func() {
+		if retErr != nil {
+			_ = os.RemoveAll(instancePaths.InstanceDir)
+		}
+	}()
+
+	if cfg.WorktreePath != "" {
+		defer func() {
+			if retErr != nil {
+				_ = worktree.Remove(cfg.Workspace, cfg.WorktreePath)
+			}
+		}()
+	}
+
+	data, err := cfg.Marshal()
+	if err != nil {
+		return fmt.Errorf("serializing config: %w", err)
+	}
+	if err := os.WriteFile(instancePaths.ConfigFile, data, 0o644); err != nil {
+		return fmt.Errorf("writing instance config: %w", err)
+	}
+
+	if err := config.EnsureDir(filepath.Dir(instancePaths.RenderedDir)); err != nil {
+		return fmt.Errorf("creating rendered directory parent: %w", err)
+	}
+
+	if err := startInstance(cmd, instanceName, "", instancePaths.ConfigFile); err != nil {
+		return err
+	}
+
+	// Load instance state to get the port for MCP communication.
+	inst, err := instance.Load(instancePaths)
+	if err != nil {
+		return fmt.Errorf("loading instance state after create: %w", err)
+	}
+
+	baseURL := fmt.Sprintf("http://localhost:%d/mcp", inst.Port)
+
+	client := mcpclient.New(buildVersion)
+	defer client.Close()
+
+	// Wait for the MCP endpoint inside the container to become ready.
+	if err := waitForMCPReady(ctx, instanceName, baseURL, client); err != nil {
+		return fmt.Errorf("waiting for instance %q to become ready: %w", instanceName, err)
+	}
+
+	fmt.Fprintf(out, "\nSending prompt to %s...\n", instanceName)
+
+	toolResult, err := client.Prompt(ctx, instanceName, baseURL, runMessage)
+	if err != nil {
+		return fmt.Errorf("sending prompt to %q: %w", instanceName, err)
+	}
+
+	if !runBlocking {
+		result := promptCLIResult{
+			Instance:  instanceName,
+			Status:    "started",
+			SessionID: client.SessionID(instanceName),
+			Result:    extractMCPText(toolResult),
+		}
+		return renderRunResult(out, result)
+	}
+
+	agentResult, err := waitForAgentResult(ctx, instanceName, baseURL, client)
+	if err != nil {
+		return fmt.Errorf("waiting for result from %q: %w", instanceName, err)
+	}
+
+	result := promptCLIResult{
+		Instance:  instanceName,
+		Status:    "completed",
+		SessionID: client.SessionID(instanceName),
+		Result:    agentResult,
+	}
+	return renderRunResult(out, result)
+}
+
+func renderRunResult(out io.Writer, result promptCLIResult) error {
+	if runOutput == "json" {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	fmt.Fprintf(out, "Instance: %s\n", result.Instance)
+	fmt.Fprintf(out, "Status:   %s\n", colorStatus(result.Status))
+	if result.SessionID != "" {
+		fmt.Fprintf(out, "Session:  %s\n", result.SessionID)
+	}
+	if result.Result != "" {
+		fmt.Fprintf(out, "\n%s\n", result.Result)
+	}
+	return nil
+}
+
+// waitForMCPReady polls the agent's MCP endpoint until it responds
+// successfully or the context is cancelled. This handles the delay between
+// container start and the MCP server being fully initialized.
+func waitForMCPReady(ctx context.Context, instanceName, baseURL string, client *mcpclient.Client) error {
+	poll := 2 * time.Second
+	const maxPoll = 10 * time.Second
+	const maxWait = 2 * time.Minute
+
+	deadline := time.Now().Add(maxWait)
+
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for MCP endpoint", maxWait)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(poll):
+		}
+
+		_, err := client.Status(ctx, instanceName, baseURL)
+		if err == nil {
+			return nil
+		}
+
+		if poll < maxPoll {
+			poll = min(poll*2, maxPoll)
+		}
+	}
+}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/klausctl/pkg/mcpclient"
+)
+
+func TestRunCommandHasAllCreateFlags(t *testing.T) {
+	createFlags := []string{
+		"personality",
+		"toolchain",
+		"plugin",
+		"port",
+		"env",
+		"env-forward",
+		"permission-mode",
+		"model",
+		"system-prompt",
+		"max-budget",
+		"secret-env",
+		"secret-file",
+		"mcpserver",
+		"source",
+		"no-isolate",
+		"git-author",
+		"git-credential-helper",
+		"git-https-instead-of-ssh",
+	}
+
+	for _, flag := range createFlags {
+		assertFlagRegistered(t, runCmd, flag)
+	}
+}
+
+func TestRunCommandHasPromptFlags(t *testing.T) {
+	assertFlagRegistered(t, runCmd, "message")
+	assertFlagRegistered(t, runCmd, "blocking")
+	assertFlagRegistered(t, runCmd, "output")
+}
+
+func TestRunCommandMessageIsRequired(t *testing.T) {
+	f := runCmd.Flags().Lookup("message")
+	if f == nil {
+		t.Fatal("message flag not found")
+	}
+	// Cobra marks required flags via annotations.
+	annotations := f.Annotations
+	if _, ok := annotations["cobra_annotation_bash_completion_one_required_flag"]; !ok {
+		t.Error("expected message flag to be marked as required")
+	}
+}
+
+func TestRunCommandMessageShorthand(t *testing.T) {
+	f := runCmd.Flags().ShorthandLookup("m")
+	if f == nil {
+		t.Fatal("expected -m shorthand for --message")
+	}
+	if f.Name != "message" {
+		t.Fatalf("expected -m to map to message, got %q", f.Name)
+	}
+}
+
+func TestWaitForMCPReadyCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	client := mcpclient.New("test")
+	defer client.Close()
+
+	err := waitForMCPReady(ctx, "test-instance", "http://localhost:0/mcp", client)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestWaitForMCPReadyTimeout(t *testing.T) {
+	// Use a very short timeout context to test the timeout path quickly.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	client := mcpclient.New("test")
+	defer client.Close()
+
+	err := waitForMCPReady(ctx, "test-instance", "http://localhost:0/mcp", client)
+	if err == nil {
+		t.Fatal("expected error for unreachable endpoint")
+	}
+}

--- a/internal/tools/instance/run.go
+++ b/internal/tools/instance/run.go
@@ -1,0 +1,299 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/giantswarm/klausctl/internal/server"
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/orchestrator"
+)
+
+func registerRun(s *mcpserver.MCPServer, sc *server.ServerContext) {
+	tool := mcp.NewTool("klaus_run",
+		mcp.WithDescription("Create a new klaus instance, wait for it to become ready, and send a prompt — all in one operation"),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Instance name")),
+		mcp.WithString("message", mcp.Required(), mcp.Description("Prompt message to send to the agent after the instance is ready")),
+		mcp.WithString("workspace", mcp.Description("Workspace directory (default: current working directory)")),
+		mcp.WithString("personality", mcp.Description("Personality short name or OCI reference")),
+		mcp.WithString("toolchain", mcp.Description("Toolchain short name or OCI reference")),
+		mcp.WithArray("plugin", mcp.Description("Additional plugin short names or OCI references")),
+		mcp.WithString("source", mcp.Description("Resolve artifact short names against a specific source")),
+		mcp.WithObject("envVars", mcp.Description("Environment variable key-value pairs to set in the container (merged with any existing envVars from the resolved config)")),
+		mcp.WithArray("envForward", mcp.Description("Host environment variable names to forward to the container (merged with any existing envForward entries; duplicates are removed)")),
+		mcp.WithObject("mcpServers", mcp.Description("MCP server configurations rendered to .mcp.json (merged with any existing mcpServers from the resolved config)")),
+		mcp.WithObject("secretEnvVars", mcp.Description("Map of container env var name -> secret name; secrets are resolved from the global secrets store at start time")),
+		mcp.WithObject("secretFiles", mcp.Description("Map of container file path -> secret name; secrets are resolved, written to disk, and mounted read-only at the specified path")),
+		mcp.WithArray("mcpServerRefs", mcp.Description("Managed MCP server names to include; resolved from the global mcpservers.yaml with optional Bearer token")),
+		mcp.WithNumber("maxBudgetUsd", mcp.Description("Maximum dollar budget for the Claude agent per invocation; 0 = no limit (overrides personality default if set)")),
+		mcp.WithString("permissionMode", mcp.Description("Claude permission mode (overrides personality default): default, acceptEdits, bypassPermissions, dontAsk, plan, delegate")),
+		mcp.WithString("model", mcp.Description("Claude model (overrides personality default, e.g. sonnet, opus, claude-sonnet-4-20250514)")),
+		mcp.WithString("systemPrompt", mcp.Description("System prompt for the Claude agent (overrides personality default)")),
+		mcp.WithBoolean("noIsolate", mcp.Description("Skip git worktree creation and bind-mount workspace directly (default: false)")),
+		mcp.WithNumber("port", mcp.Description("Override auto-selected host port for the instance MCP endpoint (0 or omitted = auto-select starting from 8080)")),
+		mcp.WithString("gitAuthor", mcp.Description("Git author identity as \"Name <email>\"; sets GIT_AUTHOR_NAME/GIT_COMMITTER_NAME and GIT_AUTHOR_EMAIL/GIT_COMMITTER_EMAIL in the container")),
+		mcp.WithString("gitCredentialHelper", mcp.Description("Git credential helper (currently only \"gh\" is supported, which configures git to call \"gh auth git-credential\" for github.com)")),
+		mcp.WithBoolean("gitHttpsInsteadOfSsh", mcp.Description("Rewrite SSH git URLs (git@github.com:...) to HTTPS via container-local gitconfig (default: false)")),
+		mcp.WithBoolean("blocking", mcp.Description("Wait for the agent to complete and return the result (default: false)")),
+	)
+	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleRun(ctx, req, sc)
+	})
+}
+
+type runResult struct {
+	Instance  string `json:"instance"`
+	Status    string `json:"status"`
+	Container string `json:"container,omitempty"`
+	Image     string `json:"image,omitempty"`
+	Workspace string `json:"workspace,omitempty"`
+	Port      int    `json:"port,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	Result    string `json:"result,omitempty"`
+}
+
+func handleRun(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
+	name, err := req.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if err := config.ValidateInstanceName(name); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	message, err := req.RequireString("message")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	blocking := req.GetBool("blocking", false)
+
+	// --- Create the instance (mirrors handleCreate logic) ---
+
+	workspace := req.GetString("workspace", "")
+	if workspace == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("determining current directory: %v", err)), nil
+		}
+		workspace = cwd
+	}
+
+	personality := req.GetString("personality", "")
+	toolchain := req.GetString("toolchain", "")
+	pluginArgs := req.GetStringSlice("plugin", nil)
+
+	resolver := sc.SourceResolver()
+	sourceFilter := req.GetString("source", "")
+	if sourceFilter != "" {
+		resolver, err = resolver.ForSource(sourceFilter)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+	}
+
+	personality, toolchain, pluginArgs, err = orchestrator.ResolveCreateRefs(ctx, resolver, personality, toolchain, pluginArgs)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("resolving refs: %v", err)), nil
+	}
+
+	args := req.GetArguments()
+	envVars, err := extractStringMap(args, "envVars")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	mcpServers, err := extractObjectMap(args, "mcpServers")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	secretEnvVars, err := extractStringMap(args, "secretEnvVars")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	secretFiles, err := extractStringMap(args, "secretFiles")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	instancePaths := sc.InstancePaths(name)
+	if _, err := os.Stat(instancePaths.InstanceDir); err == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("instance %q already exists", name)), nil
+	}
+
+	port := int(req.GetFloat("port", 0))
+	if port < 0 || port > 65535 {
+		return mcp.NewToolResultError(fmt.Sprintf("port must be between 1 and 65535, got %d", port)), nil
+	}
+
+	gitAuthorName, gitAuthorEmail, err := parseGitAuthor(req.GetString("gitAuthor", ""))
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	createOpts := config.CreateOptions{
+		Name:                 name,
+		Workspace:            workspace,
+		NoIsolate:            req.GetBool("noIsolate", false),
+		Personality:          personality,
+		Toolchain:            toolchain,
+		Plugins:              pluginArgs,
+		Port:                 port,
+		GitAuthorName:        gitAuthorName,
+		GitAuthorEmail:       gitAuthorEmail,
+		GitCredentialHelper:  req.GetString("gitCredentialHelper", ""),
+		GitHTTPSInsteadOfSSH: req.GetBool("gitHttpsInsteadOfSsh", false),
+		EnvVars:              envVars,
+		EnvForward:           req.GetStringSlice("envForward", nil),
+		McpServers:           mcpServers,
+		SecretEnvVars:        secretEnvVars,
+		SecretFiles:          secretFiles,
+		McpServerRefs:        req.GetStringSlice("mcpServerRefs", nil),
+		PermissionMode:       req.GetString("permissionMode", ""),
+		Model:                req.GetString("model", ""),
+		SystemPrompt:         req.GetString("systemPrompt", ""),
+		Context:              ctx,
+		Output:               io.Discard,
+		ResolvePersonality: func(ctx context.Context, ref string, w io.Writer) (*config.ResolvedPersonality, error) {
+			if err := config.EnsureDir(sc.Paths.PersonalitiesDir); err != nil {
+				return nil, fmt.Errorf("creating personalities directory: %w", err)
+			}
+			client := orchestrator.NewDefaultClient()
+			pr, err := orchestrator.ResolvePersonality(ctx, client, ref, sc.Paths.PersonalitiesDir, io.Discard)
+			if err != nil {
+				return nil, err
+			}
+			plugins, err := orchestrator.ResolvePluginRefs(ctx, client, pr.Spec.Plugins)
+			if err != nil {
+				return nil, fmt.Errorf("resolving personality plugins: %w", err)
+			}
+			image, err := client.ResolveToolchainRef(ctx, pr.Spec.Toolchain.Ref())
+			if err != nil {
+				return nil, fmt.Errorf("resolving personality image: %w", err)
+			}
+
+			return &config.ResolvedPersonality{
+				Plugins: plugins,
+				Image:   image,
+			}, nil
+		},
+	}
+	if _, ok := args["maxBudgetUsd"]; ok {
+		b := req.GetFloat("maxBudgetUsd", 0)
+		createOpts.MaxBudgetUSD = &b
+	}
+
+	cfg, err := config.GenerateInstanceConfig(sc.Paths, createOpts)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("generating config: %v", err)), nil
+	}
+
+	if err := config.EnsureDir(instancePaths.InstanceDir); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("creating instance directory: %v", err)), nil
+	}
+	data, err := cfg.Marshal()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("serializing config: %v", err)), nil
+	}
+	if err := os.WriteFile(instancePaths.ConfigFile, data, 0o644); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("writing instance config: %v", err)), nil
+	}
+
+	if err := config.EnsureDir(filepath.Dir(instancePaths.RenderedDir)); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("creating rendered directory parent: %v", err)), nil
+	}
+
+	createRes, err := startExistingInstance(ctx, name, sc)
+	if err != nil {
+		_ = os.RemoveAll(instancePaths.InstanceDir)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// cleanupOnError stops the container and removes instance state if a
+	// post-start step (MCP readiness, prompt) fails.
+	cleanupOnError := func(stepErr error) (*mcp.CallToolResult, error) {
+		// Best-effort: stop and remove the container we just started.
+		cleanupContainer(context.Background(), name, nil)
+		_ = os.RemoveAll(instancePaths.InstanceDir)
+		return mcp.NewToolResultError(stepErr.Error()), nil
+	}
+
+	// --- Wait for MCP readiness, then send the prompt ---
+
+	baseURL := fmt.Sprintf("http://localhost:%d/mcp", createRes.Port)
+
+	if err := waitForMCPReadyMCP(ctx, name, baseURL, sc); err != nil {
+		return cleanupOnError(fmt.Errorf("waiting for instance %q to become ready: %v", name, err))
+	}
+
+	toolResult, err := sc.MCPClient.Prompt(ctx, name, baseURL, message)
+	if err != nil {
+		return cleanupOnError(fmt.Errorf("sending prompt to %q: %v", name, err))
+	}
+
+	if !blocking {
+		return server.JSONResult(runResult{
+			Instance:  name,
+			Status:    "started",
+			Container: createRes.Container,
+			Image:     createRes.Image,
+			Workspace: createRes.Workspace,
+			Port:      createRes.Port,
+			SessionID: sc.MCPClient.SessionID(name),
+			Result:    extractText(toolResult),
+		})
+	}
+
+	agentRes, err := waitForResult(ctx, name, baseURL, sc)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("waiting for result from %q: %v", name, err)), nil
+	}
+
+	return server.JSONResult(runResult{
+		Instance:  name,
+		Status:    "completed",
+		Container: createRes.Container,
+		Image:     createRes.Image,
+		Workspace: createRes.Workspace,
+		Port:      createRes.Port,
+		SessionID: sc.MCPClient.SessionID(name),
+		Result:    agentRes,
+	})
+}
+
+// waitForMCPReadyMCP polls the agent's MCP endpoint until it responds or
+// the context is cancelled / times out.
+func waitForMCPReadyMCP(ctx context.Context, name, baseURL string, sc *server.ServerContext) error {
+	poll := 2 * time.Second
+	const maxPoll = 10 * time.Second
+	const maxWait = 2 * time.Minute
+
+	deadline := time.Now().Add(maxWait)
+
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for MCP endpoint", maxWait)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(poll):
+		}
+
+		_, err := sc.MCPClient.Status(ctx, name, baseURL)
+		if err == nil {
+			return nil
+		}
+
+		if poll < maxPoll {
+			poll = min(poll*2, maxPoll)
+		}
+	}
+}

--- a/internal/tools/instance/run_test.go
+++ b/internal/tools/instance/run_test.go
@@ -1,0 +1,40 @@
+package instance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/klausctl/internal/server"
+	"github.com/giantswarm/klausctl/pkg/mcpclient"
+)
+
+func TestWaitForMCPReadyMCPCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	sc := &server.ServerContext{
+		MCPClient: mcpclient.New("test"),
+	}
+	defer sc.MCPClient.Close()
+
+	err := waitForMCPReadyMCP(ctx, "test-instance", "http://localhost:0/mcp", sc)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestWaitForMCPReadyMCPTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	sc := &server.ServerContext{
+		MCPClient: mcpclient.New("test"),
+	}
+	defer sc.MCPClient.Close()
+
+	err := waitForMCPReadyMCP(ctx, "test-instance", "http://localhost:0/mcp", sc)
+	if err == nil {
+		t.Fatal("expected error for unreachable endpoint")
+	}
+}

--- a/internal/tools/instance/tools.go
+++ b/internal/tools/instance/tools.go
@@ -39,6 +39,7 @@ func RegisterTools(s *mcpserver.MCPServer, sc *server.ServerContext) {
 	registerList(s, sc)
 	registerPrompt(s, sc)
 	registerResult(s, sc)
+	registerRun(s, sc)
 }
 
 func registerCreate(s *mcpserver.MCPServer, sc *server.ServerContext) {


### PR DESCRIPTION
## Summary

- Adds `klausctl run` CLI command that combines `create` + `prompt` into a single operation
- Adds `klaus_run` MCP tool with full parity to the CLI command
- Both accept all `create` flags/parameters plus `--message`/`message` and `--blocking`/`blocking`
- After creating the instance, waits for the MCP endpoint to become ready (exponential backoff, 2min timeout) before sending the prompt
- MCP handler properly cleans up container and instance directory on post-start failures (readiness timeout, prompt failure)
- Includes port validation on the CLI side

Closes giantswarm/giantswarm#35968

## Test plan

- [x] `TestRunCommandHasAllCreateFlags` — verifies all create flags are registered on `run`
- [x] `TestRunCommandHasPromptFlags` — verifies message, blocking, output flags
- [x] `TestRunCommandMessageIsRequired` — verifies message flag is required
- [x] `TestRunCommandMessageShorthand` — verifies `-m` shorthand works
- [x] `TestWaitForMCPReadyCancelledContext` — context cancellation stops polling
- [x] `TestWaitForMCPReadyTimeout` — unreachable endpoint times out
- [x] `TestWaitForMCPReadyMCPCancelledContext` — MCP-side context cancellation
- [x] `TestWaitForMCPReadyMCPTimeout` — MCP-side timeout
- [x] All existing tests pass (only pre-existing failures in `pkg/orchestrator` due to read-only filesystem)
- [ ] Manual: `klausctl run dev ~/project -m "list files"` creates instance and sends prompt
- [ ] Manual: `klausctl run dev ~/project -m "fix tests" --blocking` waits for result

🤖 Generated with [Claude Code](https://claude.com/claude-code)