### PR TITLE
refactor: extract shared create logic from run command

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -4,16 +4,13 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/klausctl/pkg/config"
 	"github.com/giantswarm/klausctl/pkg/instance"
-	"github.com/giantswarm/klausctl/pkg/orchestrator"
 	"github.com/giantswarm/klausctl/pkg/worktree"
 )
 
@@ -90,187 +87,41 @@ func init() {
 	rootCmd.AddCommand(createCmd)
 }
 
-func runCreate(cmd *cobra.Command, args []string) (retErr error) {
-	baseName := args[0]
-	if err := config.ValidateInstanceName(baseName); err != nil {
-		return err
-	}
-
-	instanceName := baseName
-	if createGenerateSuffix {
-		suffixed, err := instance.AppendSuffix(baseName)
-		if err != nil {
-			return fmt.Errorf("generating name suffix: %w", err)
-		}
-		instanceName = suffixed
-	}
-
-	if err := config.ValidateInstanceName(instanceName); err != nil {
-		return err
-	}
-
+func runCreate(cmd *cobra.Command, args []string) error {
 	workspace := ""
 	if len(args) > 1 {
 		workspace = args[1]
-	} else {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("determining current directory: %w", err)
-		}
-		workspace = cwd
 	}
 
-	ctx := context.Background()
+	params := CLICreateParams{
+		BaseName:        args[0],
+		Workspace:       workspace,
+		Personality:     createPersonality,
+		Toolchain:       createToolchain,
+		Plugins:         createPlugins,
+		Port:            createPort,
+		Env:             createEnv,
+		EnvForward:      createEnvForward,
+		SecretEnv:       createSecretEnv,
+		SecretFile:      createSecretFile,
+		McpServer:       createMcpServer,
+		PermMode:        createPermMode,
+		Model:           createModel,
+		SystemPrompt:    createSystemPrompt,
+		MaxBudget:       createMaxBudget,
+		MaxBudgetSet:    cmd.Flags().Changed("max-budget"),
+		Source:          createSource,
+		NoIsolate:       createNoIsolate,
+		GitAuthor:       createGitAuthor,
+		GitCredHelper:   createGitCredHelper,
+		GitHTTPSInstead: createGitHTTPSInsteadOf,
+		Yes:             createYes,
+		Force:           createForce,
+		GenerateSuffix:  createGenerateSuffix,
+	}
 
-	paths, err := config.DefaultPaths()
+	instanceName, err := cliCreateInstance(context.Background(), cmd, params)
 	if err != nil {
-		return err
-	}
-	if err := config.MigrateLayout(paths); err != nil {
-		return fmt.Errorf("migrating config layout: %w", err)
-	}
-
-	instancePaths := paths.ForInstance(instanceName)
-
-	// Check for name collision with an existing instance.
-	collision, err := instance.CheckCollision(ctx, instancePaths)
-	if err != nil {
-		return fmt.Errorf("checking for existing instance: %w", err)
-	}
-
-	if err := handleCLICollision(cmd, instanceName, collision, ctx, instancePaths); err != nil {
-		return err
-	}
-
-	resolver, err := buildSourceResolver(createSource)
-	if err != nil {
-		return err
-	}
-
-	if createSource != "" {
-		fmt.Fprintf(cmd.OutOrStdout(), "Using source %q for artifact resolution\n", createSource)
-	}
-
-	personality, toolchain, plugins, err := orchestrator.ResolveCreateRefs(ctx, resolver, createPersonality, createToolchain, createPlugins)
-	if err != nil {
-		return err
-	}
-
-	envVars, err := parseEnvFlags(createEnv)
-	if err != nil {
-		return err
-	}
-
-	secretEnvVars, err := parseEnvFlags(createSecretEnv)
-	if err != nil {
-		return fmt.Errorf("parsing --secret-env: %w", err)
-	}
-
-	secretFiles, err := parseEnvFlags(createSecretFile)
-	if err != nil {
-		return fmt.Errorf("parsing --secret-file: %w", err)
-	}
-
-	gitName, gitEmail, err := parseGitAuthor(createGitAuthor)
-	if err != nil {
-		return err
-	}
-
-	opts := config.CreateOptions{
-		Name:                 instanceName,
-		Workspace:            workspace,
-		NoIsolate:            createNoIsolate,
-		Personality:          personality,
-		Toolchain:            toolchain,
-		Plugins:              plugins,
-		Port:                 createPort,
-		GitAuthorName:        gitName,
-		GitAuthorEmail:       gitEmail,
-		GitCredentialHelper:  createGitCredHelper,
-		GitHTTPSInsteadOfSSH: createGitHTTPSInsteadOf,
-		EnvVars:              envVars,
-		EnvForward:           createEnvForward,
-		SecretEnvVars:        secretEnvVars,
-		SecretFiles:          secretFiles,
-		McpServerRefs:        createMcpServer,
-		PermissionMode:       createPermMode,
-		Model:                createModel,
-		SystemPrompt:         createSystemPrompt,
-		SourceResolver:       resolver,
-		Context:              ctx,
-		Output:               cmd.OutOrStdout(),
-		ResolvePersonality: func(ctx context.Context, ref string, outWriter io.Writer) (*config.ResolvedPersonality, error) {
-			if err := config.EnsureDir(paths.PersonalitiesDir); err != nil {
-				return nil, fmt.Errorf("creating personalities directory: %w", err)
-			}
-			client := orchestrator.NewDefaultClient()
-			pr, err := orchestrator.ResolvePersonality(ctx, client, ref, paths.PersonalitiesDir, outWriter)
-			if err != nil {
-				return nil, err
-			}
-
-			plugins, err := orchestrator.ResolvePluginRefs(ctx, client, pr.Spec.Plugins)
-			if err != nil {
-				return nil, fmt.Errorf("resolving personality plugins: %w", err)
-			}
-
-			image, err := client.ResolveToolchainRef(ctx, pr.Spec.Toolchain.Ref())
-			if err != nil {
-				return nil, fmt.Errorf("resolving personality image: %w", err)
-			}
-
-			return &config.ResolvedPersonality{
-				Plugins: plugins,
-				Image:   image,
-			}, nil
-		},
-	}
-	if cmd.Flags().Changed("max-budget") {
-		opts.MaxBudgetUSD = &createMaxBudget
-	}
-
-	cfg, err := config.GenerateInstanceConfig(paths, opts)
-	if err != nil {
-		return err
-	}
-
-	if err := config.EnsureDir(instancePaths.InstanceDir); err != nil {
-		return fmt.Errorf("creating instance directory: %w", err)
-	}
-
-	// Clean up the instance directory if any subsequent step fails. This
-	// prevents leftover config/state that would block a retry of create.
-	defer func() {
-		if retErr != nil {
-			_ = os.RemoveAll(instancePaths.InstanceDir)
-		}
-	}()
-
-	// Clean up the worktree if any subsequent step fails. Registered after
-	// the instance dir defer so it runs first (LIFO), ensuring git worktree
-	// metadata is cleaned up before the directory is removed.
-	if cfg.WorktreePath != "" {
-		defer func() {
-			if retErr != nil {
-				_ = worktree.Remove(cfg.Workspace, cfg.WorktreePath)
-			}
-		}()
-	}
-
-	data, err := cfg.Marshal()
-	if err != nil {
-		return fmt.Errorf("serializing config: %w", err)
-	}
-	if err := os.WriteFile(instancePaths.ConfigFile, data, 0o644); err != nil {
-		return fmt.Errorf("writing instance config: %w", err)
-	}
-
-	// Ensure rendered output stays under the instance directory.
-	if err := config.EnsureDir(filepath.Dir(instancePaths.RenderedDir)); err != nil {
-		return fmt.Errorf("creating rendered directory parent: %w", err)
-	}
-
-	if err := startInstance(cmd, instanceName, "", instancePaths.ConfigFile); err != nil {
 		return err
 	}
 
@@ -284,13 +135,13 @@ func runCreate(cmd *cobra.Command, args []string) (retErr error) {
 // handleCLICollision handles name collision for the CLI create command.
 // It prompts or errors based on the collision state, --force, and -y flags.
 // On confirmation, it fully cleans up the old instance before returning nil.
-func handleCLICollision(cmd *cobra.Command, name string, collision instance.CollisionState, ctx context.Context, paths *config.Paths) error {
+func handleCLICollision(cmd *cobra.Command, name string, collision instance.CollisionState, force, yes bool, ctx context.Context, paths *config.Paths) error {
 	switch collision {
 	case instance.NoCollision:
 		return nil
 
 	case instance.CollisionStopped:
-		if !createYes {
+		if !yes {
 			fmt.Fprintf(cmd.OutOrStdout(), "Instance %q already exists (stopped). Replace it? [y/N]: ", name)
 			reader := bufio.NewReader(cmd.InOrStdin())
 			answer, err := reader.ReadString('\n')
@@ -305,10 +156,10 @@ func handleCLICollision(cmd *cobra.Command, name string, collision instance.Coll
 		return cleanupExistingInstance(ctx, name, paths)
 
 	case instance.CollisionRunning:
-		if !createForce {
+		if !force {
 			return fmt.Errorf("instance %q is still running; use --force to replace it", name)
 		}
-		if !createYes {
+		if !yes {
 			fmt.Fprintf(cmd.OutOrStdout(), "Instance %q is still running. Stop and replace it? [y/N]: ", name)
 			reader := bufio.NewReader(cmd.InOrStdin())
 			answer, err := reader.ReadString('\n')

--- a/cmd/create_shared.go
+++ b/cmd/create_shared.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/instance"
+	"github.com/giantswarm/klausctl/pkg/orchestrator"
+	"github.com/giantswarm/klausctl/pkg/worktree"
+)
+
+// CLICreateParams holds the flag values and resolved inputs for creating an
+// instance via the CLI. Both create and run populate this from their flags.
+type CLICreateParams struct {
+	BaseName        string
+	Workspace       string
+	Personality     string
+	Toolchain       string
+	Plugins         []string
+	Port            int
+	Env             []string
+	EnvForward      []string
+	SecretEnv       []string
+	SecretFile      []string
+	McpServer       []string
+	PermMode        string
+	Model           string
+	SystemPrompt    string
+	MaxBudget       float64
+	MaxBudgetSet    bool
+	Source          string
+	NoIsolate       bool
+	GitAuthor       string
+	GitCredHelper   string
+	GitHTTPSInstead bool
+	Yes             bool
+	Force           bool
+	GenerateSuffix  bool
+}
+
+// cliCreateInstance creates and starts a new instance from CLI parameters.
+// It handles name suffix generation, collision detection, config generation,
+// directory setup, and starting the container. On error, it cleans up any
+// partially-created state. Returns the resolved instance name.
+func cliCreateInstance(ctx context.Context, cmd *cobra.Command, params CLICreateParams) (_ string, retErr error) {
+	baseName := params.BaseName
+	if err := config.ValidateInstanceName(baseName); err != nil {
+		return "", err
+	}
+
+	instanceName := baseName
+	if params.GenerateSuffix {
+		suffixed, err := instance.AppendSuffix(baseName)
+		if err != nil {
+			return "", fmt.Errorf("generating name suffix: %w", err)
+		}
+		instanceName = suffixed
+	}
+
+	if err := config.ValidateInstanceName(instanceName); err != nil {
+		return "", err
+	}
+
+	workspace := params.Workspace
+	if workspace == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("determining current directory: %w", err)
+		}
+		workspace = cwd
+	}
+
+	if params.Port < 0 || params.Port > 65535 {
+		return "", fmt.Errorf("port must be between 0 and 65535, got %d", params.Port)
+	}
+
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return "", err
+	}
+	if err := config.MigrateLayout(paths); err != nil {
+		return "", fmt.Errorf("migrating config layout: %w", err)
+	}
+
+	instancePaths := paths.ForInstance(instanceName)
+
+	// Check for name collision with an existing instance.
+	collision, err := instance.CheckCollision(ctx, instancePaths)
+	if err != nil {
+		return "", fmt.Errorf("checking for existing instance: %w", err)
+	}
+
+	if err := handleCLICollision(cmd, instanceName, collision, params.Force, params.Yes, ctx, instancePaths); err != nil {
+		return "", err
+	}
+
+	resolver, err := buildSourceResolver(params.Source)
+	if err != nil {
+		return "", err
+	}
+
+	if params.Source != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Using source %q for artifact resolution\n", params.Source)
+	}
+
+	personality, toolchain, plugins, err := orchestrator.ResolveCreateRefs(ctx, resolver, params.Personality, params.Toolchain, params.Plugins)
+	if err != nil {
+		return "", err
+	}
+
+	envVars, err := parseEnvFlags(params.Env)
+	if err != nil {
+		return "", err
+	}
+
+	secretEnvVars, err := parseEnvFlags(params.SecretEnv)
+	if err != nil {
+		return "", fmt.Errorf("parsing --secret-env: %w", err)
+	}
+
+	secretFiles, err := parseEnvFlags(params.SecretFile)
+	if err != nil {
+		return "", fmt.Errorf("parsing --secret-file: %w", err)
+	}
+
+	gitName, gitEmail, err := parseGitAuthor(params.GitAuthor)
+	if err != nil {
+		return "", err
+	}
+
+	opts := config.CreateOptions{
+		Name:                 instanceName,
+		Workspace:            workspace,
+		NoIsolate:            params.NoIsolate,
+		Personality:          personality,
+		Toolchain:            toolchain,
+		Plugins:              plugins,
+		Port:                 params.Port,
+		GitAuthorName:        gitName,
+		GitAuthorEmail:       gitEmail,
+		GitCredentialHelper:  params.GitCredHelper,
+		GitHTTPSInsteadOfSSH: params.GitHTTPSInstead,
+		EnvVars:              envVars,
+		EnvForward:           params.EnvForward,
+		SecretEnvVars:        secretEnvVars,
+		SecretFiles:          secretFiles,
+		McpServerRefs:        params.McpServer,
+		PermissionMode:       params.PermMode,
+		Model:                params.Model,
+		SystemPrompt:         params.SystemPrompt,
+		SourceResolver:       resolver,
+		Context:              ctx,
+		Output:               cmd.OutOrStdout(),
+		ResolvePersonality: func(ctx context.Context, ref string, outWriter io.Writer) (*config.ResolvedPersonality, error) {
+			if err := config.EnsureDir(paths.PersonalitiesDir); err != nil {
+				return nil, fmt.Errorf("creating personalities directory: %w", err)
+			}
+			client := orchestrator.NewDefaultClient()
+			pr, err := orchestrator.ResolvePersonality(ctx, client, ref, paths.PersonalitiesDir, outWriter)
+			if err != nil {
+				return nil, err
+			}
+
+			plugins, err := orchestrator.ResolvePluginRefs(ctx, client, pr.Spec.Plugins)
+			if err != nil {
+				return nil, fmt.Errorf("resolving personality plugins: %w", err)
+			}
+
+			image, err := client.ResolveToolchainRef(ctx, pr.Spec.Toolchain.Ref())
+			if err != nil {
+				return nil, fmt.Errorf("resolving personality image: %w", err)
+			}
+
+			return &config.ResolvedPersonality{
+				Plugins: plugins,
+				Image:   image,
+			}, nil
+		},
+	}
+	if params.MaxBudgetSet {
+		opts.MaxBudgetUSD = &params.MaxBudget
+	}
+
+	cfg, err := config.GenerateInstanceConfig(paths, opts)
+	if err != nil {
+		return "", err
+	}
+
+	if err := config.EnsureDir(instancePaths.InstanceDir); err != nil {
+		return "", fmt.Errorf("creating instance directory: %w", err)
+	}
+
+	// Clean up the instance directory if any subsequent step fails.
+	defer func() {
+		if retErr != nil {
+			_ = os.RemoveAll(instancePaths.InstanceDir)
+		}
+	}()
+
+	// Clean up the worktree if any subsequent step fails. Registered after
+	// the instance dir defer so it runs first (LIFO).
+	if cfg.WorktreePath != "" {
+		defer func() {
+			if retErr != nil {
+				_ = worktree.Remove(cfg.Workspace, cfg.WorktreePath)
+			}
+		}()
+	}
+
+	data, err := cfg.Marshal()
+	if err != nil {
+		return "", fmt.Errorf("serializing config: %w", err)
+	}
+	if err := os.WriteFile(instancePaths.ConfigFile, data, 0o644); err != nil {
+		return "", fmt.Errorf("writing instance config: %w", err)
+	}
+
+	if err := config.EnsureDir(filepath.Dir(instancePaths.RenderedDir)); err != nil {
+		return "", fmt.Errorf("creating rendered directory parent: %w", err)
+	}
+
+	if err := startInstance(cmd, instanceName, "", instancePaths.ConfigFile); err != nil {
+		return "", err
+	}
+
+	return instanceName, nil
+}

--- a/cmd/instance_commands_test.go
+++ b/cmd/instance_commands_test.go
@@ -500,10 +500,7 @@ func TestHandleCLICollisionRunningWithoutForce(t *testing.T) {
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 
-	createForce = false
-	createYes = false
-
-	err := handleCLICollision(cmd, "running-inst", instance.CollisionRunning, context.Background(), &config.Paths{})
+	err := handleCLICollision(cmd, "running-inst", instance.CollisionRunning, false, false, context.Background(), &config.Paths{})
 	if err == nil {
 		t.Fatal("expected error for running collision without --force")
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -15,8 +14,6 @@ import (
 	"github.com/giantswarm/klausctl/pkg/config"
 	"github.com/giantswarm/klausctl/pkg/instance"
 	"github.com/giantswarm/klausctl/pkg/mcpclient"
-	"github.com/giantswarm/klausctl/pkg/orchestrator"
-	"github.com/giantswarm/klausctl/pkg/worktree"
 )
 
 var (
@@ -38,6 +35,9 @@ var (
 	runGitAuthor         string
 	runGitCredHelper     string
 	runGitHTTPSInsteadOf bool
+	runYes               bool
+	runForce             bool
+	runGenerateSuffix    bool
 
 	runMessage  string
 	runBlocking bool
@@ -85,6 +85,9 @@ func init() {
 	runCmd.Flags().StringVar(&runGitAuthor, "git-author", "", `git author identity "Name <email>"`)
 	runCmd.Flags().StringVar(&runGitCredHelper, "git-credential-helper", "", "git credential helper (currently only 'gh')")
 	runCmd.Flags().BoolVar(&runGitHTTPSInsteadOf, "git-https-instead-of-ssh", false, "rewrite SSH git URLs to HTTPS via container-local gitconfig")
+	runCmd.Flags().BoolVarP(&runYes, "yes", "y", false, "auto-confirm replacement of existing instances")
+	runCmd.Flags().BoolVar(&runForce, "force", false, "allow replacing a running instance (prompts for confirmation unless -y is also set)")
+	runCmd.Flags().BoolVar(&runGenerateSuffix, "generate-suffix", true, "append a random 4-character suffix to the instance name (use --no-generate-suffix to disable)")
 
 	runCmd.Flags().StringVarP(&runMessage, "message", "m", "", "prompt message to send to the agent (required)")
 	runCmd.Flags().BoolVar(&runBlocking, "blocking", false, "wait for the agent to complete and return the result")
@@ -93,25 +96,46 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 }
 
-func runRun(cmd *cobra.Command, args []string) (retErr error) {
-	instanceName := args[0]
-	if err := config.ValidateInstanceName(instanceName); err != nil {
-		return err
-	}
+func runRun(cmd *cobra.Command, args []string) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
 
 	workspace := ""
 	if len(args) > 1 {
 		workspace = args[1]
-	} else {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("determining current directory: %w", err)
-		}
-		workspace = cwd
 	}
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer cancel()
+	params := CLICreateParams{
+		BaseName:        args[0],
+		Workspace:       workspace,
+		Personality:     runPersonality,
+		Toolchain:       runToolchain,
+		Plugins:         runPlugins,
+		Port:            runPort,
+		Env:             runEnv,
+		EnvForward:      runEnvForward,
+		SecretEnv:       runSecretEnv,
+		SecretFile:      runSecretFile,
+		McpServer:       runMcpServer,
+		PermMode:        runPermMode,
+		Model:           runModel,
+		SystemPrompt:    runSystemPrompt,
+		MaxBudget:       runMaxBudget,
+		MaxBudgetSet:    cmd.Flags().Changed("max-budget"),
+		Source:          runSource,
+		NoIsolate:       runNoIsolate,
+		GitAuthor:       runGitAuthor,
+		GitCredHelper:   runGitCredHelper,
+		GitHTTPSInstead: runGitHTTPSInsteadOf,
+		Yes:             runYes,
+		Force:           runForce,
+		GenerateSuffix:  runGenerateSuffix,
+	}
+
+	instanceName, err := cliCreateInstance(ctx, cmd, params)
+	if err != nil {
+		return err
+	}
 
 	out := cmd.OutOrStdout()
 
@@ -119,144 +143,7 @@ func runRun(cmd *cobra.Command, args []string) (retErr error) {
 	if err != nil {
 		return err
 	}
-	if err := config.MigrateLayout(paths); err != nil {
-		return fmt.Errorf("migrating config layout: %w", err)
-	}
-
 	instancePaths := paths.ForInstance(instanceName)
-	if _, err := os.Stat(instancePaths.InstanceDir); err == nil {
-		return fmt.Errorf("instance %q already exists", instanceName)
-	}
-
-	resolver, err := buildSourceResolver(runSource)
-	if err != nil {
-		return err
-	}
-
-	if runSource != "" {
-		fmt.Fprintf(out, "Using source %q for artifact resolution\n", runSource)
-	}
-
-	personality, toolchain, plugins, err := orchestrator.ResolveCreateRefs(ctx, resolver, runPersonality, runToolchain, runPlugins)
-	if err != nil {
-		return err
-	}
-
-	envVars, err := parseEnvFlags(runEnv)
-	if err != nil {
-		return err
-	}
-
-	secretEnvVars, err := parseEnvFlags(runSecretEnv)
-	if err != nil {
-		return fmt.Errorf("parsing --secret-env: %w", err)
-	}
-
-	secretFiles, err := parseEnvFlags(runSecretFile)
-	if err != nil {
-		return fmt.Errorf("parsing --secret-file: %w", err)
-	}
-
-	if runPort < 0 || runPort > 65535 {
-		return fmt.Errorf("port must be between 0 and 65535, got %d", runPort)
-	}
-
-	gitName, gitEmail, err := parseGitAuthor(runGitAuthor)
-	if err != nil {
-		return err
-	}
-
-	opts := config.CreateOptions{
-		Name:                 instanceName,
-		Workspace:            workspace,
-		NoIsolate:            runNoIsolate,
-		Personality:          personality,
-		Toolchain:            toolchain,
-		Plugins:              plugins,
-		Port:                 runPort,
-		GitAuthorName:        gitName,
-		GitAuthorEmail:       gitEmail,
-		GitCredentialHelper:  runGitCredHelper,
-		GitHTTPSInsteadOfSSH: runGitHTTPSInsteadOf,
-		EnvVars:              envVars,
-		EnvForward:           runEnvForward,
-		SecretEnvVars:        secretEnvVars,
-		SecretFiles:          secretFiles,
-		McpServerRefs:        runMcpServer,
-		PermissionMode:       runPermMode,
-		Model:                runModel,
-		SystemPrompt:         runSystemPrompt,
-		SourceResolver:       resolver,
-		Context:              ctx,
-		Output:               out,
-		ResolvePersonality: func(ctx context.Context, ref string, outWriter io.Writer) (*config.ResolvedPersonality, error) {
-			if err := config.EnsureDir(paths.PersonalitiesDir); err != nil {
-				return nil, fmt.Errorf("creating personalities directory: %w", err)
-			}
-			client := orchestrator.NewDefaultClient()
-			pr, err := orchestrator.ResolvePersonality(ctx, client, ref, paths.PersonalitiesDir, outWriter)
-			if err != nil {
-				return nil, err
-			}
-
-			plugins, err := orchestrator.ResolvePluginRefs(ctx, client, pr.Spec.Plugins)
-			if err != nil {
-				return nil, fmt.Errorf("resolving personality plugins: %w", err)
-			}
-
-			image, err := client.ResolveToolchainRef(ctx, pr.Spec.Toolchain.Ref())
-			if err != nil {
-				return nil, fmt.Errorf("resolving personality image: %w", err)
-			}
-
-			return &config.ResolvedPersonality{
-				Plugins: plugins,
-				Image:   image,
-			}, nil
-		},
-	}
-	if cmd.Flags().Changed("max-budget") {
-		opts.MaxBudgetUSD = &runMaxBudget
-	}
-
-	cfg, err := config.GenerateInstanceConfig(paths, opts)
-	if err != nil {
-		return err
-	}
-
-	if err := config.EnsureDir(instancePaths.InstanceDir); err != nil {
-		return fmt.Errorf("creating instance directory: %w", err)
-	}
-
-	defer func() {
-		if retErr != nil {
-			_ = os.RemoveAll(instancePaths.InstanceDir)
-		}
-	}()
-
-	if cfg.WorktreePath != "" {
-		defer func() {
-			if retErr != nil {
-				_ = worktree.Remove(cfg.Workspace, cfg.WorktreePath)
-			}
-		}()
-	}
-
-	data, err := cfg.Marshal()
-	if err != nil {
-		return fmt.Errorf("serializing config: %w", err)
-	}
-	if err := os.WriteFile(instancePaths.ConfigFile, data, 0o644); err != nil {
-		return fmt.Errorf("writing instance config: %w", err)
-	}
-
-	if err := config.EnsureDir(filepath.Dir(instancePaths.RenderedDir)); err != nil {
-		return fmt.Errorf("creating rendered directory parent: %w", err)
-	}
-
-	if err := startInstance(cmd, instanceName, "", instancePaths.ConfigFile); err != nil {
-		return err
-	}
 
 	// Load instance state to get the port for MCP communication.
 	inst, err := instance.Load(instancePaths)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -28,6 +28,9 @@ func TestRunCommandHasAllCreateFlags(t *testing.T) {
 		"git-author",
 		"git-credential-helper",
 		"git-https-instead-of-ssh",
+		"yes",
+		"force",
+		"generate-suffix",
 	}
 
 	for _, flag := range createFlags {

--- a/internal/tools/instance/create_shared.go
+++ b/internal/tools/instance/create_shared.go
@@ -1,0 +1,250 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/giantswarm/klausctl/internal/server"
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/instance"
+	"github.com/giantswarm/klausctl/pkg/orchestrator"
+	"github.com/giantswarm/klausctl/pkg/worktree"
+)
+
+// mcpCreateParams holds the parsed parameters for creating an instance via MCP.
+type mcpCreateParams struct {
+	name           string
+	generateSuffix bool
+	force          bool
+	confirm        bool
+	workspace      string
+	personality    string
+	toolchain      string
+	pluginArgs     []string
+	sourceFilter   string
+	envVars        map[string]string
+	mcpServers     map[string]any
+	secretEnvVars  map[string]string
+	secretFiles    map[string]string
+	envForward     []string
+	mcpServerRefs  []string
+	port           int
+	gitAuthorName  string
+	gitAuthorEmail string
+	gitCredHelper  string
+	gitHTTPS       bool
+	noIsolate      bool
+	permissionMode string
+	model          string
+	systemPrompt   string
+	maxBudgetUSD   *float64
+}
+
+// parseMCPCreateParams extracts common create parameters from an MCP request.
+func parseMCPCreateParams(req mcp.CallToolRequest) (*mcpCreateParams, error) {
+	name, err := req.RequireString("name")
+	if err != nil {
+		return nil, err
+	}
+	if err := config.ValidateInstanceName(name); err != nil {
+		return nil, err
+	}
+
+	workspace := req.GetString("workspace", "")
+	if workspace == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("determining current directory: %v", err)
+		}
+		workspace = cwd
+	}
+
+	args := req.GetArguments()
+	envVars, err := extractStringMap(args, "envVars")
+	if err != nil {
+		return nil, err
+	}
+	mcpServers, err := extractObjectMap(args, "mcpServers")
+	if err != nil {
+		return nil, err
+	}
+	secretEnvVars, err := extractStringMap(args, "secretEnvVars")
+	if err != nil {
+		return nil, err
+	}
+	secretFiles, err := extractStringMap(args, "secretFiles")
+	if err != nil {
+		return nil, err
+	}
+
+	port := int(req.GetFloat("port", 0))
+	if port < 0 || port > 65535 {
+		return nil, fmt.Errorf("port must be between 1 and 65535, got %d", port)
+	}
+
+	gitAuthorName, gitAuthorEmail, err := parseGitAuthor(req.GetString("gitAuthor", ""))
+	if err != nil {
+		return nil, err
+	}
+
+	p := &mcpCreateParams{
+		name:           name,
+		generateSuffix: req.GetBool("generateSuffix", true),
+		force:          req.GetBool("force", false),
+		confirm:        req.GetBool("confirm", false),
+		workspace:      workspace,
+		personality:    req.GetString("personality", ""),
+		toolchain:      req.GetString("toolchain", ""),
+		pluginArgs:     req.GetStringSlice("plugin", nil),
+		sourceFilter:   req.GetString("source", ""),
+		envVars:        envVars,
+		mcpServers:     mcpServers,
+		secretEnvVars:  secretEnvVars,
+		secretFiles:    secretFiles,
+		envForward:     req.GetStringSlice("envForward", nil),
+		mcpServerRefs:  req.GetStringSlice("mcpServerRefs", nil),
+		port:           port,
+		gitAuthorName:  gitAuthorName,
+		gitAuthorEmail: gitAuthorEmail,
+		gitCredHelper:  req.GetString("gitCredentialHelper", ""),
+		gitHTTPS:       req.GetBool("gitHttpsInsteadOfSsh", false),
+		noIsolate:      req.GetBool("noIsolate", false),
+		permissionMode: req.GetString("permissionMode", ""),
+		model:          req.GetString("model", ""),
+		systemPrompt:   req.GetString("systemPrompt", ""),
+	}
+
+	if _, ok := args["maxBudgetUsd"]; ok {
+		b := req.GetFloat("maxBudgetUsd", 0)
+		p.maxBudgetUSD = &b
+	}
+
+	return p, nil
+}
+
+// mcpCreateInstance creates and starts a new instance from MCP parameters.
+// It handles name suffix generation, collision detection, config generation,
+// directory setup, and starting the container. Returns the create result.
+func mcpCreateInstance(ctx context.Context, params *mcpCreateParams, sc *server.ServerContext) (*createResult, error) {
+	name := params.name
+	if params.generateSuffix {
+		suffixed, err := instance.AppendSuffix(name)
+		if err != nil {
+			return nil, fmt.Errorf("generating name suffix: %v", err)
+		}
+		name = suffixed
+	}
+
+	if err := config.ValidateInstanceName(name); err != nil {
+		return nil, err
+	}
+
+	instancePaths := sc.InstancePaths(name)
+
+	// Check for name collision before expensive network calls.
+	collision, err := instance.CheckCollision(ctx, instancePaths)
+	if err != nil {
+		return nil, fmt.Errorf("checking for existing instance: %v", err)
+	}
+
+	if err := handleMCPCollision(ctx, name, collision, params.force, params.confirm, instancePaths, sc); err != nil {
+		return nil, err
+	}
+
+	resolver := sc.SourceResolver()
+	if params.sourceFilter != "" {
+		resolver, err = resolver.ForSource(params.sourceFilter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	personality, toolchain, pluginArgs, err := orchestrator.ResolveCreateRefs(ctx, resolver, params.personality, params.toolchain, params.pluginArgs)
+	if err != nil {
+		return nil, fmt.Errorf("resolving refs: %v", err)
+	}
+
+	createOpts := config.CreateOptions{
+		Name:                 name,
+		Workspace:            params.workspace,
+		NoIsolate:            params.noIsolate,
+		Personality:          personality,
+		Toolchain:            toolchain,
+		Plugins:              pluginArgs,
+		Port:                 params.port,
+		GitAuthorName:        params.gitAuthorName,
+		GitAuthorEmail:       params.gitAuthorEmail,
+		GitCredentialHelper:  params.gitCredHelper,
+		GitHTTPSInsteadOfSSH: params.gitHTTPS,
+		EnvVars:              params.envVars,
+		EnvForward:           params.envForward,
+		McpServers:           params.mcpServers,
+		SecretEnvVars:        params.secretEnvVars,
+		SecretFiles:          params.secretFiles,
+		McpServerRefs:        params.mcpServerRefs,
+		PermissionMode:       params.permissionMode,
+		Model:                params.model,
+		SystemPrompt:         params.systemPrompt,
+		MaxBudgetUSD:         params.maxBudgetUSD,
+		Context:              ctx,
+		Output:               io.Discard,
+		ResolvePersonality: func(ctx context.Context, ref string, w io.Writer) (*config.ResolvedPersonality, error) {
+			if err := config.EnsureDir(sc.Paths.PersonalitiesDir); err != nil {
+				return nil, fmt.Errorf("creating personalities directory: %w", err)
+			}
+			client := orchestrator.NewDefaultClient()
+			pr, err := orchestrator.ResolvePersonality(ctx, client, ref, sc.Paths.PersonalitiesDir, io.Discard)
+			if err != nil {
+				return nil, err
+			}
+			plugins, err := orchestrator.ResolvePluginRefs(ctx, client, pr.Spec.Plugins)
+			if err != nil {
+				return nil, fmt.Errorf("resolving personality plugins: %w", err)
+			}
+			image, err := client.ResolveToolchainRef(ctx, pr.Spec.Toolchain.Ref())
+			if err != nil {
+				return nil, fmt.Errorf("resolving personality image: %w", err)
+			}
+
+			return &config.ResolvedPersonality{
+				Plugins: plugins,
+				Image:   image,
+			}, nil
+		},
+	}
+
+	cfg, err := config.GenerateInstanceConfig(sc.Paths, createOpts)
+	if err != nil {
+		return nil, fmt.Errorf("generating config: %v", err)
+	}
+
+	if err := config.EnsureDir(instancePaths.InstanceDir); err != nil {
+		return nil, fmt.Errorf("creating instance directory: %v", err)
+	}
+	data, err := cfg.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("serializing config: %v", err)
+	}
+	if err := os.WriteFile(instancePaths.ConfigFile, data, 0o644); err != nil {
+		return nil, fmt.Errorf("writing instance config: %v", err)
+	}
+
+	if err := config.EnsureDir(filepath.Dir(instancePaths.RenderedDir)); err != nil {
+		return nil, fmt.Errorf("creating rendered directory parent: %v", err)
+	}
+
+	result, err := startExistingInstance(ctx, name, sc)
+	if err != nil {
+		if cfg.WorktreePath != "" {
+			_ = worktree.Remove(cfg.Workspace, cfg.WorktreePath)
+		}
+		_ = os.RemoveAll(instancePaths.InstanceDir)
+		return nil, err
+	}
+	return result, nil
+}

--- a/internal/tools/instance/run.go
+++ b/internal/tools/instance/run.go
@@ -3,17 +3,13 @@ package instance
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
 	"github.com/giantswarm/klausctl/internal/server"
-	"github.com/giantswarm/klausctl/pkg/config"
-	"github.com/giantswarm/klausctl/pkg/orchestrator"
 )
 
 func registerRun(s *mcpserver.MCPServer, sc *server.ServerContext) {
@@ -41,6 +37,9 @@ func registerRun(s *mcpserver.MCPServer, sc *server.ServerContext) {
 		mcp.WithString("gitAuthor", mcp.Description("Git author identity as \"Name <email>\"; sets GIT_AUTHOR_NAME/GIT_COMMITTER_NAME and GIT_AUTHOR_EMAIL/GIT_COMMITTER_EMAIL in the container")),
 		mcp.WithString("gitCredentialHelper", mcp.Description("Git credential helper (currently only \"gh\" is supported, which configures git to call \"gh auth git-credential\" for github.com)")),
 		mcp.WithBoolean("gitHttpsInsteadOfSsh", mcp.Description("Rewrite SSH git URLs (git@github.com:...) to HTTPS via container-local gitconfig (default: false)")),
+		mcp.WithBoolean("generateSuffix", mcp.Description("Append a random 4-character suffix to the instance name to avoid collisions (default: true)")),
+		mcp.WithBoolean("force", mcp.Description("Allow replacing a running instance; requires confirm: true as well")),
+		mcp.WithBoolean("confirm", mcp.Description("Confirm replacement of an existing instance; required when a name collision is detected")),
 		mcp.WithBoolean("blocking", mcp.Description("Wait for the agent to complete and return the result (default: false)")),
 	)
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -60,14 +59,6 @@ type runResult struct {
 }
 
 func handleRun(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
-	name, err := req.RequireString("name")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	if err := config.ValidateInstanceName(name); err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-
 	message, err := req.RequireString("message")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -75,145 +66,19 @@ func handleRun(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerCo
 
 	blocking := req.GetBool("blocking", false)
 
-	// --- Create the instance (mirrors handleCreate logic) ---
-
-	workspace := req.GetString("workspace", "")
-	if workspace == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("determining current directory: %v", err)), nil
-		}
-		workspace = cwd
-	}
-
-	personality := req.GetString("personality", "")
-	toolchain := req.GetString("toolchain", "")
-	pluginArgs := req.GetStringSlice("plugin", nil)
-
-	resolver := sc.SourceResolver()
-	sourceFilter := req.GetString("source", "")
-	if sourceFilter != "" {
-		resolver, err = resolver.ForSource(sourceFilter)
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
-		}
-	}
-
-	personality, toolchain, pluginArgs, err = orchestrator.ResolveCreateRefs(ctx, resolver, personality, toolchain, pluginArgs)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("resolving refs: %v", err)), nil
-	}
-
-	args := req.GetArguments()
-	envVars, err := extractStringMap(args, "envVars")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	mcpServers, err := extractObjectMap(args, "mcpServers")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	secretEnvVars, err := extractStringMap(args, "secretEnvVars")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	secretFiles, err := extractStringMap(args, "secretFiles")
+	// Create the instance using the shared create logic.
+	params, err := parseMCPCreateParams(req)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	createRes, err := mcpCreateInstance(ctx, params, sc)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	name := createRes.Instance
 	instancePaths := sc.InstancePaths(name)
-	if _, err := os.Stat(instancePaths.InstanceDir); err == nil {
-		return mcp.NewToolResultError(fmt.Sprintf("instance %q already exists", name)), nil
-	}
-
-	port := int(req.GetFloat("port", 0))
-	if port < 0 || port > 65535 {
-		return mcp.NewToolResultError(fmt.Sprintf("port must be between 1 and 65535, got %d", port)), nil
-	}
-
-	gitAuthorName, gitAuthorEmail, err := parseGitAuthor(req.GetString("gitAuthor", ""))
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-
-	createOpts := config.CreateOptions{
-		Name:                 name,
-		Workspace:            workspace,
-		NoIsolate:            req.GetBool("noIsolate", false),
-		Personality:          personality,
-		Toolchain:            toolchain,
-		Plugins:              pluginArgs,
-		Port:                 port,
-		GitAuthorName:        gitAuthorName,
-		GitAuthorEmail:       gitAuthorEmail,
-		GitCredentialHelper:  req.GetString("gitCredentialHelper", ""),
-		GitHTTPSInsteadOfSSH: req.GetBool("gitHttpsInsteadOfSsh", false),
-		EnvVars:              envVars,
-		EnvForward:           req.GetStringSlice("envForward", nil),
-		McpServers:           mcpServers,
-		SecretEnvVars:        secretEnvVars,
-		SecretFiles:          secretFiles,
-		McpServerRefs:        req.GetStringSlice("mcpServerRefs", nil),
-		PermissionMode:       req.GetString("permissionMode", ""),
-		Model:                req.GetString("model", ""),
-		SystemPrompt:         req.GetString("systemPrompt", ""),
-		Context:              ctx,
-		Output:               io.Discard,
-		ResolvePersonality: func(ctx context.Context, ref string, w io.Writer) (*config.ResolvedPersonality, error) {
-			if err := config.EnsureDir(sc.Paths.PersonalitiesDir); err != nil {
-				return nil, fmt.Errorf("creating personalities directory: %w", err)
-			}
-			client := orchestrator.NewDefaultClient()
-			pr, err := orchestrator.ResolvePersonality(ctx, client, ref, sc.Paths.PersonalitiesDir, io.Discard)
-			if err != nil {
-				return nil, err
-			}
-			plugins, err := orchestrator.ResolvePluginRefs(ctx, client, pr.Spec.Plugins)
-			if err != nil {
-				return nil, fmt.Errorf("resolving personality plugins: %w", err)
-			}
-			image, err := client.ResolveToolchainRef(ctx, pr.Spec.Toolchain.Ref())
-			if err != nil {
-				return nil, fmt.Errorf("resolving personality image: %w", err)
-			}
-
-			return &config.ResolvedPersonality{
-				Plugins: plugins,
-				Image:   image,
-			}, nil
-		},
-	}
-	if _, ok := args["maxBudgetUsd"]; ok {
-		b := req.GetFloat("maxBudgetUsd", 0)
-		createOpts.MaxBudgetUSD = &b
-	}
-
-	cfg, err := config.GenerateInstanceConfig(sc.Paths, createOpts)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("generating config: %v", err)), nil
-	}
-
-	if err := config.EnsureDir(instancePaths.InstanceDir); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("creating instance directory: %v", err)), nil
-	}
-	data, err := cfg.Marshal()
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("serializing config: %v", err)), nil
-	}
-	if err := os.WriteFile(instancePaths.ConfigFile, data, 0o644); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("writing instance config: %v", err)), nil
-	}
-
-	if err := config.EnsureDir(filepath.Dir(instancePaths.RenderedDir)); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("creating rendered directory parent: %v", err)), nil
-	}
-
-	createRes, err := startExistingInstance(ctx, name, sc)
-	if err != nil {
-		_ = os.RemoveAll(instancePaths.InstanceDir)
-		return mcp.NewToolResultError(err.Error()), nil
-	}
 
 	// cleanupOnError stops the container and removes instance state if a
 	// post-start step (MCP readiness, prompt) fails.

--- a/internal/tools/instance/tools.go
+++ b/internal/tools/instance/tools.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -139,176 +138,13 @@ func registerList(s *mcpserver.MCPServer, sc *server.ServerContext) {
 // --- Handlers ---
 
 func handleCreate(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
-	baseName, err := req.RequireString("name")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	if err := config.ValidateInstanceName(baseName); err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-
-	generateSuffix := req.GetBool("generateSuffix", true)
-	force := req.GetBool("force", false)
-	confirm := req.GetBool("confirm", false)
-
-	name := baseName
-	if generateSuffix {
-		suffixed, err := instance.AppendSuffix(baseName)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("generating name suffix: %v", err)), nil
-		}
-		name = suffixed
-	}
-
-	if err := config.ValidateInstanceName(name); err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-
-	workspace := req.GetString("workspace", "")
-	if workspace == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("determining current directory: %v", err)), nil
-		}
-		workspace = cwd
-	}
-
-	personality := req.GetString("personality", "")
-	toolchain := req.GetString("toolchain", "")
-	pluginArgs := req.GetStringSlice("plugin", nil)
-
-	resolver := sc.SourceResolver()
-	sourceFilter := req.GetString("source", "")
-	if sourceFilter != "" {
-		resolver, err = resolver.ForSource(sourceFilter)
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
-		}
-	}
-
-	personality, toolchain, pluginArgs, err = orchestrator.ResolveCreateRefs(ctx, resolver, personality, toolchain, pluginArgs)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("resolving refs: %v", err)), nil
-	}
-
-	args := req.GetArguments()
-	envVars, err := extractStringMap(args, "envVars")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	mcpServers, err := extractObjectMap(args, "mcpServers")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	secretEnvVars, err := extractStringMap(args, "secretEnvVars")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	secretFiles, err := extractStringMap(args, "secretFiles")
+	params, err := parseMCPCreateParams(req)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	instancePaths := sc.InstancePaths(name)
-
-	// Check for name collision with an existing instance.
-	collision, err := instance.CheckCollision(ctx, instancePaths)
+	result, err := mcpCreateInstance(ctx, params, sc)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("checking for existing instance: %v", err)), nil
-	}
-
-	if err := handleMCPCollision(ctx, name, collision, force, confirm, instancePaths, sc); err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-
-	port := int(req.GetFloat("port", 0))
-	if port < 0 || port > 65535 {
-		return mcp.NewToolResultError(fmt.Sprintf("port must be between 1 and 65535, got %d", port)), nil
-	}
-
-	gitAuthorName, gitAuthorEmail, err := parseGitAuthor(req.GetString("gitAuthor", ""))
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-
-	createOpts := config.CreateOptions{
-		Name:                 name,
-		Workspace:            workspace,
-		NoIsolate:            req.GetBool("noIsolate", false),
-		Personality:          personality,
-		Toolchain:            toolchain,
-		Plugins:              pluginArgs,
-		Port:                 port,
-		GitAuthorName:        gitAuthorName,
-		GitAuthorEmail:       gitAuthorEmail,
-		GitCredentialHelper:  req.GetString("gitCredentialHelper", ""),
-		GitHTTPSInsteadOfSSH: req.GetBool("gitHttpsInsteadOfSsh", false),
-		EnvVars:              envVars,
-		EnvForward:           req.GetStringSlice("envForward", nil),
-		McpServers:           mcpServers,
-		SecretEnvVars:        secretEnvVars,
-		SecretFiles:          secretFiles,
-		McpServerRefs:        req.GetStringSlice("mcpServerRefs", nil),
-		PermissionMode:       req.GetString("permissionMode", ""),
-		Model:                req.GetString("model", ""),
-		SystemPrompt:         req.GetString("systemPrompt", ""),
-		Context:              ctx,
-		Output:               io.Discard,
-		ResolvePersonality: func(ctx context.Context, ref string, w io.Writer) (*config.ResolvedPersonality, error) {
-			if err := config.EnsureDir(sc.Paths.PersonalitiesDir); err != nil {
-				return nil, fmt.Errorf("creating personalities directory: %w", err)
-			}
-			client := orchestrator.NewDefaultClient()
-			pr, err := orchestrator.ResolvePersonality(ctx, client, ref, sc.Paths.PersonalitiesDir, io.Discard)
-			if err != nil {
-				return nil, err
-			}
-			plugins, err := orchestrator.ResolvePluginRefs(ctx, client, pr.Spec.Plugins)
-			if err != nil {
-				return nil, fmt.Errorf("resolving personality plugins: %w", err)
-			}
-			image, err := client.ResolveToolchainRef(ctx, pr.Spec.Toolchain.Ref())
-			if err != nil {
-				return nil, fmt.Errorf("resolving personality image: %w", err)
-			}
-
-			return &config.ResolvedPersonality{
-				Plugins: plugins,
-				Image:   image,
-			}, nil
-		},
-	}
-	if _, ok := args["maxBudgetUsd"]; ok {
-		b := req.GetFloat("maxBudgetUsd", 0)
-		createOpts.MaxBudgetUSD = &b
-	}
-
-	cfg, err := config.GenerateInstanceConfig(sc.Paths, createOpts)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("generating config: %v", err)), nil
-	}
-
-	if err := config.EnsureDir(instancePaths.InstanceDir); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("creating instance directory: %v", err)), nil
-	}
-	data, err := cfg.Marshal()
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("serializing config: %v", err)), nil
-	}
-	if err := os.WriteFile(instancePaths.ConfigFile, data, 0o644); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("writing instance config: %v", err)), nil
-	}
-
-	if err := config.EnsureDir(filepath.Dir(instancePaths.RenderedDir)); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("creating rendered directory parent: %v", err)), nil
-	}
-
-	result, err := startExistingInstance(ctx, name, sc)
-	if err != nil {
-		if cfg.WorktreePath != "" {
-			_ = worktree.Remove(cfg.Workspace, cfg.WorktreePath)
-		}
-		_ = os.RemoveAll(instancePaths.InstanceDir)
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	return server.JSONResult(result)


### PR DESCRIPTION
## Summary

- Extract the shared instance creation logic into `cliCreateInstance` (CLI path) and `mcpCreateInstance` (MCP tools path), called by both `create` and `run`
- Add collision handling (`--force`, `-y`, `--generate-suffix`) to the `run` command and `klaus_run` MCP tool, which were missing because #112 and #113 were implemented in parallel
- Reduce ~648 lines of duplicated code to ~570 lines with a single source of truth for create logic

## Changes

| File | What changed |
|------|-------------|
| `cmd/create_shared.go` | New shared `CLICreateParams` struct and `cliCreateInstance` function |
| `cmd/create.go` | `runCreate` now delegates to `cliCreateInstance` |
| `cmd/run.go` | `runRun` now delegates to `cliCreateInstance`; gains `--yes`, `--force`, `--generate-suffix` flags |
| `internal/tools/instance/create_shared.go` | New shared `mcpCreateParams`, `parseMCPCreateParams`, and `mcpCreateInstance` |
| `internal/tools/instance/tools.go` | `handleCreate` now delegates to `mcpCreateInstance` |
| `internal/tools/instance/run.go` | `handleRun` now delegates to `mcpCreateInstance`; gains `generateSuffix`, `force`, `confirm` parameters |
| `cmd/run_test.go` | Added new flags to flag-coverage test |
| `cmd/instance_commands_test.go` | Updated `handleCLICollision` call to match new signature |

## Review notes

- Addressed code-reviewer finding: `cliCreateInstance` accepts a `context.Context` so the run command's signal-aware context propagates through the create phase
- Addressed security-auditor finding: added port range validation in the CLI path (was only in MCP path)
- Reordered MCP collision check to run before expensive `ResolveCreateRefs` network call
- No behavioral changes for existing callers; all existing tests pass

Closes #115

## Test plan

- [x] All existing tests pass (`go test ./cmd/... ./internal/... ./pkg/instance/...`)
- [x] `go vet ./...` clean
- [x] Reviewed by `base:code-reviewer` and `code-quality:security-auditor` subagents
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)