### PR TITLE
fix: auto-recover from stale worktree registrations on create

### DIFF
--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -113,11 +113,34 @@ func Create(repoDir, worktreePath string) error {
 
 	// Create the worktree in detached HEAD mode pointing at origin/<branch>.
 	ref := "origin/" + branch
-	wtCmd := exec.Command("git", "worktree", "add", "--detach", worktreePath, ref)
+	wtCmd := exec.Command("git", "worktree", "add", "--detach", "--", worktreePath, ref)
 	wtCmd.Dir = repoDir
+	wtCmd.Env = append(os.Environ(), "LC_ALL=C")
 	var wtErr bytes.Buffer
 	wtCmd.Stderr = &wtErr
 	if err := wtCmd.Run(); err != nil {
+		// If the failure is due to a stale worktree registration (directory
+		// gone but .git/worktrees entry still present), prune and retry once.
+		// LC_ALL=C ensures the error message is in English regardless of locale.
+		if strings.Contains(wtErr.String(), "already registered worktree") {
+			pruneCmd := exec.Command("git", "worktree", "prune", "--expire=now")
+			pruneCmd.Dir = repoDir
+			var pruneErr bytes.Buffer
+			pruneCmd.Stderr = &pruneErr
+			if pErr := pruneCmd.Run(); pErr != nil {
+				return fmt.Errorf("git worktree prune after stale registration (original: %s): %s: %w",
+					strings.TrimSpace(wtErr.String()), strings.TrimSpace(pruneErr.String()), pErr)
+			}
+
+			retryCmd := exec.Command("git", "worktree", "add", "--detach", "--", worktreePath, ref)
+			retryCmd.Dir = repoDir
+			var retryErr bytes.Buffer
+			retryCmd.Stderr = &retryErr
+			if rErr := retryCmd.Run(); rErr != nil {
+				return fmt.Errorf("git worktree add %s (retry after prune): %s: %w", worktreePath, strings.TrimSpace(retryErr.String()), rErr)
+			}
+			return nil
+		}
 		return fmt.Errorf("git worktree add %s: %s: %w", worktreePath, strings.TrimSpace(wtErr.String()), err)
 	}
 

--- a/pkg/worktree/worktree_test.go
+++ b/pkg/worktree/worktree_test.go
@@ -312,6 +312,126 @@ func TestRemoveAlreadyDeletedDirectory(t *testing.T) {
 	}
 }
 
+func TestCreateAutoRecoveryFromStaleRegistration(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	wtPath := filepath.Join(t.TempDir(), "worktree")
+
+	// Create a worktree normally.
+	if err := Create(clone, wtPath); err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	// Simulate a stale registration: delete the worktree directory but leave
+	// the .git/worktrees entry intact (as happens on SIGKILL or power loss).
+	if err := os.RemoveAll(wtPath); err != nil {
+		t.Fatalf("removing worktree dir: %v", err)
+	}
+	// Verify the stale registration exists.
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = clone
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git worktree list: %v", err)
+	}
+	if !strings.Contains(string(out), wtPath) {
+		t.Fatal("expected stale worktree registration to still exist")
+	}
+
+	// Create again at the same path — should auto-recover via prune + retry.
+	if err := Create(clone, wtPath); err != nil {
+		t.Fatalf("Create() with stale registration error: %v", err)
+	}
+
+	// Verify the new worktree is functional.
+	data, err := os.ReadFile(filepath.Join(wtPath, "README.md"))
+	if err != nil {
+		t.Fatalf("reading README in recovered worktree: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("unexpected README content: %q", data)
+	}
+
+	// Clean up.
+	if err := Remove(clone, wtPath); err != nil {
+		t.Fatalf("Remove() error: %v", err)
+	}
+}
+
+func TestCreateDeleteCreateCycle(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	wtPath := filepath.Join(t.TempDir(), "worktree")
+
+	// Run three full create-delete cycles on the same path to verify no
+	// stale registrations accumulate.
+	for i := 0; i < 3; i++ {
+		if err := Create(clone, wtPath); err != nil {
+			t.Fatalf("cycle %d: Create() error: %v", i, err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(wtPath, "README.md"))
+		if err != nil {
+			t.Fatalf("cycle %d: reading README: %v", i, err)
+		}
+		if string(data) != "hello" {
+			t.Fatalf("cycle %d: unexpected README content: %q", i, data)
+		}
+
+		if err := Remove(clone, wtPath); err != nil {
+			t.Fatalf("cycle %d: Remove() error: %v", i, err)
+		}
+	}
+}
+
+func TestCreateNonStaleErrorFailsImmediately(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	wtPath := filepath.Join(t.TempDir(), "worktree")
+
+	// Create a live worktree at this path.
+	if err := Create(clone, wtPath); err != nil {
+		t.Fatalf("initial Create() error: %v", err)
+	}
+
+	// Attempt to create again at the same path while the worktree is still
+	// live. Git produces "already exists" rather than "already registered
+	// worktree", so the prune+retry recovery must NOT be triggered.
+	wtPath2 := filepath.Join(t.TempDir(), "worktree2")
+	err := Create(clone, wtPath2)
+	// This should succeed (different path). Now test the actual guard: try
+	// creating at wtPath again while it is live.
+	if err != nil {
+		t.Fatalf("Create(wtPath2) error: %v", err)
+	}
+	_ = Remove(clone, wtPath2)
+
+	// The real test: create at the same path as a live worktree. The error
+	// from git will NOT contain "already registered worktree" so prune+retry
+	// must not trigger.
+	err = Create(clone, wtPath)
+	if err == nil {
+		// Some git versions may succeed by creating at an occupied path;
+		// in that case the guard is moot. Clean up and skip.
+		_ = Remove(clone, wtPath)
+		t.Skip("git worktree add succeeded on occupied path; cannot test guard")
+	}
+	if strings.Contains(err.Error(), "retry after prune") {
+		t.Fatalf("non-stale error incorrectly triggered prune+retry: %v", err)
+	}
+	if !strings.Contains(err.Error(), "git worktree add") {
+		t.Fatalf("unexpected error format: %v", err)
+	}
+
+	// Clean up.
+	if err := Remove(clone, wtPath); err != nil {
+		t.Fatalf("Remove() error: %v", err)
+	}
+}
+
 func TestLockRepo(t *testing.T) {
 	bare := initBareRepo(t)
 	clone := cloneRepo(t, bare)


### PR DESCRIPTION
## Problem

When `klausctl create` tries to create a worktree for workspace isolation, it fails if a stale registration exists in the source repo's `.git/worktrees/` from a previous instance that wasn't fully cleaned up (SIGKILL, power loss, pre-rollback deletion). The user must manually run `git worktree prune` before retrying.

Hit in every marge sweep and lifecycle reliability trial since worktree isolation was introduced.

## Solution

Add self-healing to `worktree.Create()`: when `git worktree add` fails with the "already registered worktree" error, run `git worktree prune --expire=now` on the source repo and retry the add once.

Key implementation details:
- Uses `LC_ALL=C` on the git command to ensure reliable error message parsing across locales
- Uses `--expire=now` on prune so recently-stale entries are cleaned immediately
- Retry happens at most once (no infinite loops)
- Non-stale errors fail immediately without triggering the recovery path
- Adds `--` separator before positional args for safety

## Tests

3 new tests (all pass, 12 total):

| Test | Coverage |
|------|----------|
| `TestCreateAutoRecoveryFromStaleRegistration` | Stale registration simulated by deleting worktree dir -> Create recovers via prune+retry |
| `TestCreateDeleteCreateCycle` | 3 full create-delete-create cycles on same path |
| `TestCreateNonStaleErrorFailsImmediately` | Live worktree conflict does NOT trigger prune+retry |

Fixes #101

Made with [Cursor](https://cursor.com)