### PR TITLE
fix: replace git worktree with local clone for container isolation (#114)

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -62,11 +62,11 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Load instance config to check for worktree before removing anything.
+	// Load instance config to check for workspace clone before removing anything.
 	cfg, _ := config.Load(paths.ConfigFile)
 	if cfg != nil && cfg.WorktreePath != "" {
 		if err := worktree.Remove(cfg.Workspace, cfg.WorktreePath); err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to remove git worktree: %v\n", err)
+			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to remove workspace clone: %v\n", err)
 		}
 	}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -94,9 +94,9 @@ func startInstance(cmd *cobra.Command, instanceName, workspaceOverride, configPa
 	if cfg.WorktreePath != "" {
 		if _, err := os.Stat(cfg.WorktreePath); err != nil {
 			if os.IsNotExist(err) {
-				return fmt.Errorf("worktree directory does not exist: %s", cfg.WorktreePath)
+				return fmt.Errorf("workspace clone directory does not exist: %s", cfg.WorktreePath)
 			}
-			return fmt.Errorf("checking worktree directory: %w", err)
+			return fmt.Errorf("checking workspace clone directory: %w", err)
 		}
 	}
 

--- a/internal/tools/instance/tools.go
+++ b/internal/tools/instance/tools.go
@@ -183,7 +183,7 @@ func mcpCleanupExistingInstance(ctx context.Context, name string, paths *config.
 	cfg, _ := config.Load(paths.ConfigFile)
 	if cfg != nil && cfg.WorktreePath != "" {
 		if err := worktree.Remove(cfg.Workspace, cfg.WorktreePath); err != nil {
-			log.Printf("Warning: failed to remove git worktree: %v", err)
+			log.Printf("Warning: failed to remove workspace clone: %v", err)
 		}
 	}
 
@@ -287,7 +287,7 @@ func handleDelete(ctx context.Context, req mcp.CallToolRequest, sc *server.Serve
 	cfg, _ := config.Load(paths.ConfigFile)
 	if cfg != nil && cfg.WorktreePath != "" {
 		if err := worktree.Remove(cfg.Workspace, cfg.WorktreePath); err != nil {
-			log.Printf("Warning: failed to remove git worktree: %v", err)
+			log.Printf("Warning: failed to remove workspace clone: %v", err)
 		}
 	}
 
@@ -512,9 +512,9 @@ func startExistingInstance(ctx context.Context, name string, sc *server.ServerCo
 	if cfg.WorktreePath != "" {
 		if _, err := os.Stat(cfg.WorktreePath); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				return nil, fmt.Errorf("worktree directory does not exist: %s", cfg.WorktreePath)
+				return nil, fmt.Errorf("workspace clone directory does not exist: %s", cfg.WorktreePath)
 			}
-			return nil, fmt.Errorf("checking worktree directory: %w", err)
+			return nil, fmt.Errorf("checking workspace clone directory: %w", err)
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,9 +35,9 @@ type Config struct {
 	// Workspace is the host directory to mount into the container at /workspace.
 	Workspace string `yaml:"workspace"`
 
-	// WorktreePath is the path to the git worktree created for this instance.
+	// WorktreePath is the path to the local git clone created for this instance.
 	// When set, this path is bind-mounted instead of Workspace, and Workspace
-	// stores the original repository path for worktree lifecycle management.
+	// stores the original repository path for clone lifecycle management.
 	WorktreePath string `yaml:"worktreePath,omitempty"`
 
 	// Port is the host port mapped to the container's MCP endpoint (8080).

--- a/pkg/config/generate.go
+++ b/pkg/config/generate.go
@@ -85,17 +85,17 @@ func GenerateInstanceConfig(paths *Paths, opts CreateOptions) (*Config, error) {
 	cfg := DefaultConfig()
 	cfg.Workspace = workspace
 
-	// Create a git worktree for isolation when the workspace is a git repo.
+	// Create a local clone for isolation when the workspace is a git repo.
 	if !opts.NoIsolate && worktree.IsGitRepo(workspace) {
 		instanceDir := filepath.Join(paths.InstancesDir, opts.Name)
 		wtPath := filepath.Join(instanceDir, "workspace")
 
 		if err := EnsureDir(instanceDir); err != nil {
-			return nil, fmt.Errorf("creating instance directory for worktree: %w", err)
+			return nil, fmt.Errorf("creating instance directory for workspace clone: %w", err)
 		}
 
 		if err := worktree.Create(workspace, wtPath); err != nil {
-			return nil, fmt.Errorf("creating git worktree: %w", err)
+			return nil, fmt.Errorf("creating workspace clone: %w", err)
 		}
 
 		cfg.WorktreePath = wtPath

--- a/pkg/config/worktree_integration_test.go
+++ b/pkg/config/worktree_integration_test.go
@@ -83,8 +83,19 @@ func TestGenerateInstanceConfig_CreatesWorktreeForGitRepo(t *testing.T) {
 		t.Fatalf("expected Workspace=%q (original repo), got %q", clone, cfg.Workspace)
 	}
 
-	// Clean up the worktree to avoid git warnings.
-	gitRun(t, clone, "worktree", "remove", "--force", cfg.WorktreePath)
+	// Verify the clone has a self-contained .git directory (not a file).
+	info, err := os.Stat(filepath.Join(cfg.WorktreePath, ".git"))
+	if err != nil {
+		t.Fatalf("stat .git in clone: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("expected .git to be a directory in clone, not a file")
+	}
+
+	// Clean up the clone.
+	if err := os.RemoveAll(cfg.WorktreePath); err != nil {
+		t.Fatalf("removing clone: %v", err)
+	}
 }
 
 func TestGenerateInstanceConfig_NoIsolateSkipsWorktree(t *testing.T) {

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -1,6 +1,7 @@
-// Package worktree manages git worktrees for workspace isolation.
-// When a workspace path is a git repository, a worktree can be created
-// so each instance gets its own working tree while sharing .git/objects.
+// Package worktree manages cloned workspaces for instance isolation.
+// When a workspace path is a git repository, a local clone is created
+// so each instance gets its own self-contained .git directory that
+// works inside containers without additional volume mounts.
 package worktree
 
 import (
@@ -10,12 +11,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 )
 
 // IsGitRepo reports whether the given directory is a git repository root
-// (has a .git directory). Nested worktrees (.git file) are not considered
-// since they cannot be used as the parent repository for new worktrees.
+// (has a .git directory). Clones (.git file pointing elsewhere) are not
+// considered since they are not suitable as clone sources.
 func IsGitRepo(dir string) bool {
 	info, err := os.Stat(filepath.Join(dir, ".git"))
 	if err != nil {
@@ -25,7 +25,7 @@ func IsGitRepo(dir string) bool {
 }
 
 // DefaultBranch returns the default branch of the remote "origin" in the given
-// git repository. It runs `git remote show origin` and parses the HEAD branch.
+// git repository. It runs `git symbolic-ref` and parses the HEAD branch.
 // Falls back to "main" if the default branch cannot be determined.
 func DefaultBranch(repoDir string) (string, error) {
 	cmd := exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD")
@@ -62,42 +62,31 @@ func DefaultBranch(repoDir string) (string, error) {
 	return "main", nil
 }
 
-// lockRepo acquires an exclusive filesystem lock on the source repository's
-// .git directory. This serializes worktree operations to prevent concurrent
-// git commands from corrupting worktree references.
-// The caller must call the returned unlock function when done.
-func lockRepo(repoDir string) (unlock func(), err error) {
-	lockPath := filepath.Join(repoDir, ".git", "klausctl.lock")
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+// upstreamURL returns the URL of the "origin" remote in the given repository.
+func upstreamURL(repoDir string) (string, error) {
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("opening lock file %s: %w", lockPath, err)
+		return "", fmt.Errorf("git remote get-url origin: %w", err)
 	}
-
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		f.Close()
-		return nil, fmt.Errorf("acquiring lock on %s: %w", lockPath, err)
+	url := strings.TrimSpace(string(out))
+	if url == "" {
+		return "", fmt.Errorf("origin remote URL is empty")
 	}
-
-	return func() {
-		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-		_ = f.Close()
-	}, nil
+	return url, nil
 }
 
-// Create creates a git worktree at worktreePath from the given repository
-// directory. It fetches origin, determines the default branch, and creates
-// a detached worktree at origin/<default-branch>.
+// Create creates a local clone at clonePath from the given repository
+// directory. It uses `git clone --local --no-checkout` for efficiency
+// (hardlinks objects on the same filesystem), then checks out a detached
+// HEAD at origin/<default-branch> and fixes up the origin remote URL to
+// point at the upstream remote rather than the local repo path.
 //
-// An exclusive filesystem lock is held for the duration of the operation to
-// prevent concurrent worktree creation from corrupting git references.
-func Create(repoDir, worktreePath string) error {
-	unlock, err := lockRepo(repoDir)
-	if err != nil {
-		return fmt.Errorf("locking repo: %w", err)
-	}
-	defer unlock()
-
-	// Fetch latest from origin.
+// The resulting clone has a self-contained .git directory that works
+// inside containers without additional volume mounts.
+func Create(repoDir, clonePath string) error {
+	// Fetch latest from origin before cloning.
 	fetchCmd := exec.Command("git", "fetch", "origin")
 	fetchCmd.Dir = repoDir
 	var fetchErr bytes.Buffer
@@ -106,114 +95,55 @@ func Create(repoDir, worktreePath string) error {
 		return fmt.Errorf("git fetch origin: %s: %w", strings.TrimSpace(fetchErr.String()), err)
 	}
 
+	// Get the upstream remote URL before cloning (--local sets origin to the
+	// local path, so we need the real upstream URL to fix it up afterward).
+	upstream, err := upstreamURL(repoDir)
+	if err != nil {
+		return fmt.Errorf("determining upstream URL: %w", err)
+	}
+
 	branch, err := DefaultBranch(repoDir)
 	if err != nil {
 		return fmt.Errorf("determining default branch: %w", err)
 	}
 
-	// Create the worktree in detached HEAD mode pointing at origin/<branch>.
+	// Clone locally with --no-checkout so we can detach at the right ref.
+	cloneCmd := exec.Command("git", "clone", "--local", "--no-checkout", repoDir, clonePath)
+	var cloneErr bytes.Buffer
+	cloneCmd.Stderr = &cloneErr
+	if err := cloneCmd.Run(); err != nil {
+		return fmt.Errorf("git clone --local %s: %s: %w", repoDir, strings.TrimSpace(cloneErr.String()), err)
+	}
+
+	// Checkout detached HEAD at origin/<default-branch>.
 	ref := "origin/" + branch
-	wtCmd := exec.Command("git", "worktree", "add", "--detach", "--", worktreePath, ref)
-	wtCmd.Dir = repoDir
-	wtCmd.Env = append(os.Environ(), "LC_ALL=C")
-	var wtErr bytes.Buffer
-	wtCmd.Stderr = &wtErr
-	if err := wtCmd.Run(); err != nil {
-		// If the failure is due to a stale worktree registration (directory
-		// gone but .git/worktrees entry still present), prune and retry once.
-		// LC_ALL=C ensures the error message is in English regardless of locale.
-		if strings.Contains(wtErr.String(), "already registered worktree") {
-			pruneCmd := exec.Command("git", "worktree", "prune", "--expire=now")
-			pruneCmd.Dir = repoDir
-			var pruneErr bytes.Buffer
-			pruneCmd.Stderr = &pruneErr
-			if pErr := pruneCmd.Run(); pErr != nil {
-				return fmt.Errorf("git worktree prune after stale registration (original: %s): %s: %w",
-					strings.TrimSpace(wtErr.String()), strings.TrimSpace(pruneErr.String()), pErr)
-			}
+	checkoutCmd := exec.Command("git", "checkout", "--detach", ref)
+	checkoutCmd.Dir = clonePath
+	var checkoutErr bytes.Buffer
+	checkoutCmd.Stderr = &checkoutErr
+	if err := checkoutCmd.Run(); err != nil {
+		// Clean up the partial clone on failure.
+		_ = os.RemoveAll(clonePath)
+		return fmt.Errorf("git checkout --detach %s: %s: %w", ref, strings.TrimSpace(checkoutErr.String()), err)
+	}
 
-			retryCmd := exec.Command("git", "worktree", "add", "--detach", "--", worktreePath, ref)
-			retryCmd.Dir = repoDir
-			var retryErr bytes.Buffer
-			retryCmd.Stderr = &retryErr
-			if rErr := retryCmd.Run(); rErr != nil {
-				return fmt.Errorf("git worktree add %s (retry after prune): %s: %w", worktreePath, strings.TrimSpace(retryErr.String()), rErr)
-			}
-			return nil
-		}
-		return fmt.Errorf("git worktree add %s: %s: %w", worktreePath, strings.TrimSpace(wtErr.String()), err)
+	// Fix up the origin remote to point at the real upstream, not the local path.
+	setURLCmd := exec.Command("git", "remote", "set-url", "origin", upstream)
+	setURLCmd.Dir = clonePath
+	var setURLErr bytes.Buffer
+	setURLCmd.Stderr = &setURLErr
+	if err := setURLCmd.Run(); err != nil {
+		_ = os.RemoveAll(clonePath)
+		return fmt.Errorf("git remote set-url origin %s: %s: %w", upstream, strings.TrimSpace(setURLErr.String()), err)
 	}
 
 	return nil
 }
 
-// Remove removes a git worktree with a resilient fallback chain. It first
-// tries `git worktree remove`, then `git worktree remove --force`, and
-// finally falls back to manual directory removal with `git worktree prune`.
-//
-// The repoDir is the original repository (not the worktree itself).
-//
-// An exclusive filesystem lock is held for the duration of the operation to
-// prevent concurrent worktree operations from corrupting git references.
-func Remove(repoDir, worktreePath string) error {
-	unlock, err := lockRepo(repoDir)
-	if err != nil {
-		return fmt.Errorf("locking repo: %w", err)
-	}
-	defer unlock()
-
-	// Try normal remove.
-	normalErr := gitWorktreeRemove(repoDir, worktreePath, false)
-	if normalErr == nil {
-		return nil
-	}
-
-	// Fall back to force remove.
-	forceErr := gitWorktreeRemove(repoDir, worktreePath, true)
-	if forceErr == nil {
-		return nil
-	}
-
-	// Last resort: remove directory manually and prune stale worktree entries.
-	if err := removeWorktreeManually(repoDir, worktreePath); err != nil {
-		return fmt.Errorf("all removal strategies failed (normal: %v; force: %v; manual: %w)", normalErr, forceErr, err)
-	}
-	return nil
-}
-
-// gitWorktreeRemove runs `git worktree remove` with an optional --force flag.
-func gitWorktreeRemove(repoDir, worktreePath string, force bool) error {
-	args := []string{"worktree", "remove"}
-	if force {
-		args = append(args, "--force")
-	}
-	args = append(args, "--", worktreePath)
-
-	cmd := exec.Command("git", args...)
-	cmd.Dir = repoDir
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("git worktree remove %s: %s: %w", worktreePath, strings.TrimSpace(stderr.String()), err)
-	}
-	return nil
-}
-
-// removeWorktreeManually deletes the worktree directory and runs
-// `git worktree prune` to clean up stale references. This is the last-resort
-// fallback when git worktree remove commands fail.
-func removeWorktreeManually(repoDir, worktreePath string) error {
-	if err := os.RemoveAll(worktreePath); err != nil {
-		return fmt.Errorf("removing worktree directory %s: %w", worktreePath, err)
-	}
-
-	cmd := exec.Command("git", "worktree", "prune")
-	cmd.Dir = repoDir
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("git worktree prune: %s: %w", strings.TrimSpace(stderr.String()), err)
-	}
-
-	return nil
+// Remove removes a cloned workspace by deleting its directory.
+// The repoDir parameter is accepted for backward compatibility but ignored,
+// since clones are self-contained and do not require cleanup in the source repo.
+func Remove(repoDir, clonePath string) error {
+	_ = repoDir // kept for backward compatibility; clones are self-contained
+	return os.RemoveAll(clonePath)
 }

--- a/pkg/worktree/worktree_test.go
+++ b/pkg/worktree/worktree_test.go
@@ -86,69 +86,109 @@ func TestCreateAndRemove(t *testing.T) {
 	bare := initBareRepo(t)
 	clone := cloneRepo(t, bare)
 
-	wtPath := filepath.Join(t.TempDir(), "worktree")
+	clonedPath := filepath.Join(t.TempDir(), "instance-workspace")
 
-	if err := Create(clone, wtPath); err != nil {
+	if err := Create(clone, clonedPath); err != nil {
 		t.Fatalf("Create() error: %v", err)
 	}
 
-	// Verify the worktree directory exists and has the README.
-	readme := filepath.Join(wtPath, "README.md")
+	// Verify the clone directory exists and has the README.
+	readme := filepath.Join(clonedPath, "README.md")
 	data, err := os.ReadFile(readme)
 	if err != nil {
-		t.Fatalf("reading README in worktree: %v", err)
+		t.Fatalf("reading README in clone: %v", err)
 	}
 	if string(data) != "hello" {
 		t.Fatalf("unexpected README content: %q", data)
 	}
 
-	// Verify it's a git worktree (has .git file, not directory).
-	gitPath := filepath.Join(wtPath, ".git")
+	// Verify it's a full clone (has .git directory, not a file).
+	gitPath := filepath.Join(clonedPath, ".git")
 	info, err := os.Stat(gitPath)
 	if err != nil {
-		t.Fatalf("stat .git in worktree: %v", err)
+		t.Fatalf("stat .git in clone: %v", err)
 	}
-	if info.IsDir() {
-		t.Fatal("expected .git to be a file in worktree, not a directory")
+	if !info.IsDir() {
+		t.Fatal("expected .git to be a directory in clone, not a file")
 	}
 
-	// Remove the worktree.
-	if err := Remove(clone, wtPath); err != nil {
+	// Verify the origin remote points to the upstream (bare repo), not the local clone.
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = clonedPath
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git remote get-url origin: %v", err)
+	}
+	originURL := strings.TrimSpace(string(out))
+	if originURL != bare {
+		t.Fatalf("expected origin URL %q, got %q", bare, originURL)
+	}
+
+	// Remove the clone.
+	if err := Remove(clone, clonedPath); err != nil {
 		t.Fatalf("Remove() error: %v", err)
 	}
 
-	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
-		t.Fatalf("expected worktree directory to be removed, stat err: %v", err)
+	if _, err := os.Stat(clonedPath); !os.IsNotExist(err) {
+		t.Fatalf("expected clone directory to be removed, stat err: %v", err)
 	}
 }
 
-func TestCreateMultipleWorktrees(t *testing.T) {
+func TestCreateProducesSelfContainedGitDir(t *testing.T) {
 	bare := initBareRepo(t)
 	clone := cloneRepo(t, bare)
 
-	wt1 := filepath.Join(t.TempDir(), "wt1")
-	wt2 := filepath.Join(t.TempDir(), "wt2")
+	clonedPath := filepath.Join(t.TempDir(), "instance-workspace")
 
-	if err := Create(clone, wt1); err != nil {
-		t.Fatalf("Create(wt1) error: %v", err)
+	if err := Create(clone, clonedPath); err != nil {
+		t.Fatalf("Create() error: %v", err)
 	}
-	if err := Create(clone, wt2); err != nil {
-		t.Fatalf("Create(wt2) error: %v", err)
+
+	// The key invariant: git operations work in the clone without access to
+	// the source repo. Simulate container isolation by verifying git commands
+	// succeed using only the clone's .git directory.
+	for _, args := range [][]string{
+		{"rev-parse", "--is-inside-work-tree"},
+		{"log", "--oneline", "-1"},
+		{"remote", "-v"},
+		{"status"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = clonedPath
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s failed in clone: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+}
+
+func TestCreateMultipleClones(t *testing.T) {
+	bare := initBareRepo(t)
+	clone := cloneRepo(t, bare)
+
+	c1 := filepath.Join(t.TempDir(), "c1")
+	c2 := filepath.Join(t.TempDir(), "c2")
+
+	if err := Create(clone, c1); err != nil {
+		t.Fatalf("Create(c1) error: %v", err)
+	}
+	if err := Create(clone, c2); err != nil {
+		t.Fatalf("Create(c2) error: %v", err)
 	}
 
 	// Both should have the README.
-	for _, wt := range []string{wt1, wt2} {
-		if _, err := os.ReadFile(filepath.Join(wt, "README.md")); err != nil {
-			t.Fatalf("missing README in %s: %v", wt, err)
+	for _, c := range []string{c1, c2} {
+		if _, err := os.ReadFile(filepath.Join(c, "README.md")); err != nil {
+			t.Fatalf("missing README in %s: %v", c, err)
 		}
 	}
 
 	// Clean up both.
-	if err := Remove(clone, wt1); err != nil {
-		t.Fatalf("Remove(wt1) error: %v", err)
+	if err := Remove(clone, c1); err != nil {
+		t.Fatalf("Remove(c1) error: %v", err)
 	}
-	if err := Remove(clone, wt2); err != nil {
-		t.Fatalf("Remove(wt2) error: %v", err)
+	if err := Remove(clone, c2); err != nil {
+		t.Fatalf("Remove(c2) error: %v", err)
 	}
 }
 
@@ -157,19 +197,19 @@ func TestConcurrentCreate(t *testing.T) {
 	clone := cloneRepo(t, bare)
 
 	const n = 5
-	wtPaths := make([]string, n)
-	for i := range wtPaths {
-		wtPaths[i] = filepath.Join(t.TempDir(), fmt.Sprintf("wt%d", i))
+	clonePaths := make([]string, n)
+	for i := range clonePaths {
+		clonePaths[i] = filepath.Join(t.TempDir(), fmt.Sprintf("c%d", i))
 	}
 
-	// Create all worktrees concurrently.
+	// Create all clones concurrently.
 	var wg sync.WaitGroup
 	errs := make([]error, n)
 	for i := 0; i < n; i++ {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			errs[idx] = Create(clone, wtPaths[idx])
+			errs[idx] = Create(clone, clonePaths[idx])
 		}(i)
 	}
 	wg.Wait()
@@ -177,185 +217,38 @@ func TestConcurrentCreate(t *testing.T) {
 	// All creations must succeed.
 	for i, err := range errs {
 		if err != nil {
-			t.Fatalf("Create(wt%d) error: %v", i, err)
+			t.Fatalf("Create(c%d) error: %v", i, err)
 		}
 	}
 
-	// Every worktree must have the README and a valid git remote.
-	for i, wt := range wtPaths {
-		data, err := os.ReadFile(filepath.Join(wt, "README.md"))
+	// Every clone must have the README and a valid git remote pointing upstream.
+	for i, c := range clonePaths {
+		data, err := os.ReadFile(filepath.Join(c, "README.md"))
 		if err != nil {
-			t.Fatalf("wt%d: missing README: %v", i, err)
+			t.Fatalf("c%d: missing README: %v", i, err)
 		}
 		if string(data) != "hello" {
-			t.Fatalf("wt%d: unexpected README content: %q", i, data)
+			t.Fatalf("c%d: unexpected README content: %q", i, data)
 		}
 
-		// Verify git remote is intact.
-		cmd := exec.Command("git", "remote", "-v")
-		cmd.Dir = wt
+		// Verify git remote points to upstream.
+		cmd := exec.Command("git", "remote", "get-url", "origin")
+		cmd.Dir = c
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			t.Fatalf("wt%d: git remote -v failed: %v\n%s", i, err, out)
+			t.Fatalf("c%d: git remote get-url failed: %v\n%s", i, err, out)
 		}
-		if !strings.Contains(string(out), "origin") {
-			t.Fatalf("wt%d: missing origin remote: %s", i, out)
-		}
-	}
-
-	// Clean up all worktrees.
-	for i, wt := range wtPaths {
-		if err := Remove(clone, wt); err != nil {
-			t.Errorf("Remove(wt%d) error: %v", i, err)
+		url := strings.TrimSpace(string(out))
+		if url != bare {
+			t.Fatalf("c%d: expected origin URL %q, got %q", i, bare, url)
 		}
 	}
-}
 
-func TestRemoveFallsBackToForce(t *testing.T) {
-	bare := initBareRepo(t)
-	clone := cloneRepo(t, bare)
-
-	wtPath := filepath.Join(t.TempDir(), "worktree")
-
-	if err := Create(clone, wtPath); err != nil {
-		t.Fatalf("Create() error: %v", err)
-	}
-
-	// Modify a tracked file so `git worktree remove` (without --force) fails
-	// due to uncommitted changes.
-	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("modified"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Remove should succeed via the --force fallback.
-	if err := Remove(clone, wtPath); err != nil {
-		t.Fatalf("Remove() error: %v", err)
-	}
-
-	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
-		t.Fatalf("expected worktree directory to be removed, stat err: %v", err)
-	}
-}
-
-func TestRemoveFallsBackToManualCleanup(t *testing.T) {
-	bare := initBareRepo(t)
-	clone := cloneRepo(t, bare)
-
-	wtPath := filepath.Join(t.TempDir(), "worktree")
-
-	if err := Create(clone, wtPath); err != nil {
-		t.Fatalf("Create() error: %v", err)
-	}
-
-	// Corrupt the worktree by replacing the .git file with garbage.
-	// This makes both `git worktree remove` and `git worktree remove --force`
-	// fail because git cannot validate the worktree.
-	gitFile := filepath.Join(wtPath, ".git")
-	if err := os.Remove(gitFile); err != nil {
-		t.Fatalf("removing .git file: %v", err)
-	}
-	if err := os.WriteFile(gitFile, []byte("garbage"), 0o644); err != nil {
-		t.Fatalf("writing corrupt .git file: %v", err)
-	}
-
-	// Remove should succeed via the manual removal + prune fallback.
-	if err := Remove(clone, wtPath); err != nil {
-		t.Fatalf("Remove() error: %v", err)
-	}
-
-	// Verify the worktree directory is gone.
-	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
-		t.Fatalf("expected worktree directory to be removed, stat err: %v", err)
-	}
-
-	// Verify git no longer lists the worktree.
-	cmd := exec.Command("git", "worktree", "list", "--porcelain")
-	cmd.Dir = clone
-	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("git worktree list: %v", err)
-	}
-	if strings.Contains(string(out), wtPath) {
-		t.Fatalf("expected worktree to be pruned from git, but still listed:\n%s", out)
-	}
-}
-
-func TestRemoveAlreadyDeletedDirectory(t *testing.T) {
-	bare := initBareRepo(t)
-	clone := cloneRepo(t, bare)
-
-	wtPath := filepath.Join(t.TempDir(), "worktree")
-
-	if err := Create(clone, wtPath); err != nil {
-		t.Fatalf("Create() error: %v", err)
-	}
-
-	// Manually delete the worktree directory to simulate partial cleanup.
-	if err := os.RemoveAll(wtPath); err != nil {
-		t.Fatal(err)
-	}
-
-	// Remove should still succeed (manual fallback prunes the stale reference).
-	if err := Remove(clone, wtPath); err != nil {
-		t.Fatalf("Remove() error: %v", err)
-	}
-
-	// Verify git no longer lists the worktree.
-	cmd := exec.Command("git", "worktree", "list", "--porcelain")
-	cmd.Dir = clone
-	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("git worktree list: %v", err)
-	}
-	if strings.Contains(string(out), wtPath) {
-		t.Fatalf("expected stale worktree to be pruned, but still listed:\n%s", out)
-	}
-}
-
-func TestCreateAutoRecoveryFromStaleRegistration(t *testing.T) {
-	bare := initBareRepo(t)
-	clone := cloneRepo(t, bare)
-
-	wtPath := filepath.Join(t.TempDir(), "worktree")
-
-	// Create a worktree normally.
-	if err := Create(clone, wtPath); err != nil {
-		t.Fatalf("Create() error: %v", err)
-	}
-
-	// Simulate a stale registration: delete the worktree directory but leave
-	// the .git/worktrees entry intact (as happens on SIGKILL or power loss).
-	if err := os.RemoveAll(wtPath); err != nil {
-		t.Fatalf("removing worktree dir: %v", err)
-	}
-	// Verify the stale registration exists.
-	cmd := exec.Command("git", "worktree", "list", "--porcelain")
-	cmd.Dir = clone
-	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("git worktree list: %v", err)
-	}
-	if !strings.Contains(string(out), wtPath) {
-		t.Fatal("expected stale worktree registration to still exist")
-	}
-
-	// Create again at the same path — should auto-recover via prune + retry.
-	if err := Create(clone, wtPath); err != nil {
-		t.Fatalf("Create() with stale registration error: %v", err)
-	}
-
-	// Verify the new worktree is functional.
-	data, err := os.ReadFile(filepath.Join(wtPath, "README.md"))
-	if err != nil {
-		t.Fatalf("reading README in recovered worktree: %v", err)
-	}
-	if string(data) != "hello" {
-		t.Fatalf("unexpected README content: %q", data)
-	}
-
-	// Clean up.
-	if err := Remove(clone, wtPath); err != nil {
-		t.Fatalf("Remove() error: %v", err)
+	// Clean up all clones.
+	for i, c := range clonePaths {
+		if err := Remove(clone, c); err != nil {
+			t.Errorf("Remove(c%d) error: %v", i, err)
+		}
 	}
 }
 
@@ -363,16 +256,15 @@ func TestCreateDeleteCreateCycle(t *testing.T) {
 	bare := initBareRepo(t)
 	clone := cloneRepo(t, bare)
 
-	wtPath := filepath.Join(t.TempDir(), "worktree")
+	clonedPath := filepath.Join(t.TempDir(), "instance-workspace")
 
-	// Run three full create-delete cycles on the same path to verify no
-	// stale registrations accumulate.
+	// Run three full create-delete cycles on the same path.
 	for i := 0; i < 3; i++ {
-		if err := Create(clone, wtPath); err != nil {
+		if err := Create(clone, clonedPath); err != nil {
 			t.Fatalf("cycle %d: Create() error: %v", i, err)
 		}
 
-		data, err := os.ReadFile(filepath.Join(wtPath, "README.md"))
+		data, err := os.ReadFile(filepath.Join(clonedPath, "README.md"))
 		if err != nil {
 			t.Fatalf("cycle %d: reading README: %v", i, err)
 		}
@@ -380,81 +272,54 @@ func TestCreateDeleteCreateCycle(t *testing.T) {
 			t.Fatalf("cycle %d: unexpected README content: %q", i, data)
 		}
 
-		if err := Remove(clone, wtPath); err != nil {
+		if err := Remove(clone, clonedPath); err != nil {
 			t.Fatalf("cycle %d: Remove() error: %v", i, err)
 		}
 	}
 }
 
-func TestCreateNonStaleErrorFailsImmediately(t *testing.T) {
+func TestRemoveAlreadyDeletedDirectory(t *testing.T) {
 	bare := initBareRepo(t)
 	clone := cloneRepo(t, bare)
 
-	wtPath := filepath.Join(t.TempDir(), "worktree")
+	clonedPath := filepath.Join(t.TempDir(), "instance-workspace")
 
-	// Create a live worktree at this path.
-	if err := Create(clone, wtPath); err != nil {
-		t.Fatalf("initial Create() error: %v", err)
-	}
-
-	// Attempt to create again at the same path while the worktree is still
-	// live. Git produces "already exists" rather than "already registered
-	// worktree", so the prune+retry recovery must NOT be triggered.
-	wtPath2 := filepath.Join(t.TempDir(), "worktree2")
-	err := Create(clone, wtPath2)
-	// This should succeed (different path). Now test the actual guard: try
-	// creating at wtPath again while it is live.
-	if err != nil {
-		t.Fatalf("Create(wtPath2) error: %v", err)
-	}
-	_ = Remove(clone, wtPath2)
-
-	// The real test: create at the same path as a live worktree. The error
-	// from git will NOT contain "already registered worktree" so prune+retry
-	// must not trigger.
-	err = Create(clone, wtPath)
-	if err == nil {
-		// Some git versions may succeed by creating at an occupied path;
-		// in that case the guard is moot. Clean up and skip.
-		_ = Remove(clone, wtPath)
-		t.Skip("git worktree add succeeded on occupied path; cannot test guard")
-	}
-	if strings.Contains(err.Error(), "retry after prune") {
-		t.Fatalf("non-stale error incorrectly triggered prune+retry: %v", err)
-	}
-	if !strings.Contains(err.Error(), "git worktree add") {
-		t.Fatalf("unexpected error format: %v", err)
+	if err := Create(clone, clonedPath); err != nil {
+		t.Fatalf("Create() error: %v", err)
 	}
 
-	// Clean up.
-	if err := Remove(clone, wtPath); err != nil {
+	// Manually delete the directory to simulate partial cleanup.
+	if err := os.RemoveAll(clonedPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove should succeed (os.RemoveAll on non-existent path returns nil).
+	if err := Remove(clone, clonedPath); err != nil {
 		t.Fatalf("Remove() error: %v", err)
 	}
 }
 
-func TestLockRepo(t *testing.T) {
+func TestRemoveWithModifiedFiles(t *testing.T) {
 	bare := initBareRepo(t)
 	clone := cloneRepo(t, bare)
 
-	// Acquire lock.
-	unlock, err := lockRepo(clone)
-	if err != nil {
-		t.Fatalf("lockRepo() error: %v", err)
+	clonedPath := filepath.Join(t.TempDir(), "instance-workspace")
+
+	if err := Create(clone, clonedPath); err != nil {
+		t.Fatalf("Create() error: %v", err)
 	}
 
-	// Verify lock file was created.
-	lockPath := filepath.Join(clone, ".git", "klausctl.lock")
-	if _, err := os.Stat(lockPath); err != nil {
-		t.Fatalf("lock file not created: %v", err)
+	// Modify a tracked file.
+	if err := os.WriteFile(filepath.Join(clonedPath, "README.md"), []byte("modified"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 
-	// Release lock.
-	unlock()
-
-	// Lock can be acquired again after release.
-	unlock2, err := lockRepo(clone)
-	if err != nil {
-		t.Fatalf("lockRepo() after release error: %v", err)
+	// Remove should succeed unconditionally (just deletes the directory).
+	if err := Remove(clone, clonedPath); err != nil {
+		t.Fatalf("Remove() error: %v", err)
 	}
-	unlock2()
+
+	if _, err := os.Stat(clonedPath); !os.IsNotExist(err) {
+		t.Fatalf("expected clone directory to be removed, stat err: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

Replace `git worktree add` with `git clone --local` for workspace isolation. Worktrees produce a `.git` file with an absolute `gitdir:` reference to the host's `.git/worktrees/<name>` directory, which is not accessible inside the container. Local clones produce a self-contained `.git` directory that works without additional volume mounts.

- `worktree.Create()` now uses `git clone --local --no-checkout` + detached checkout + remote URL fixup
- `worktree.Remove()` simplified to `os.RemoveAll` (clones are independent, no git bookkeeping needed)
- Removed filesystem locking (`lockRepo`) -- clones don't share `.git/worktrees/` state
- Updated all error messages and comments from "worktree" to "workspace clone"
- Tests rewritten to verify clone semantics (self-contained `.git` directory, correct upstream URL)

Fixes #114