### PR TITLE
Feat: archive CLI/MCP improvements (#125)

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -12,6 +13,7 @@ import (
 )
 
 var archiveOutput string
+var archiveShowFull bool
 
 var archiveCmd = &cobra.Command{
 	Use:   "archive",
@@ -34,19 +36,10 @@ var archiveShowCmd = &cobra.Command{
 
 func init() {
 	archiveCmd.PersistentFlags().StringVarP(&archiveOutput, "output", "o", "text", "output format: text, json")
+	archiveShowCmd.Flags().BoolVar(&archiveShowFull, "full", false, "include the full messages array in the output")
 	archiveCmd.AddCommand(archiveListCmd)
 	archiveCmd.AddCommand(archiveShowCmd)
 	rootCmd.AddCommand(archiveCmd)
-}
-
-// archiveListSummary is the text/json representation for the list command.
-type archiveListSummary struct {
-	UUID         string   `json:"uuid"`
-	Name         string   `json:"name"`
-	Status       string   `json:"status"`
-	StoppedAt    string   `json:"stopped_at"`
-	MessageCount int      `json:"message_count"`
-	TotalCostUSD *float64 `json:"total_cost_usd,omitempty"`
 }
 
 func runArchiveList(cmd *cobra.Command, _ []string) error {
@@ -63,16 +56,9 @@ func runArchiveList(cmd *cobra.Command, _ []string) error {
 	out := cmd.OutOrStdout()
 
 	if archiveOutput == "json" {
-		summaries := make([]archiveListSummary, 0, len(entries))
+		summaries := make([]archive.ListSummary, 0, len(entries))
 		for _, e := range entries {
-			summaries = append(summaries, archiveListSummary{
-				UUID:         e.UUID,
-				Name:         e.Name,
-				Status:       e.Status,
-				StoppedAt:    e.StoppedAt.Format("2006-01-02T15:04:05Z07:00"),
-				MessageCount: e.MessageCount,
-				TotalCostUSD: e.TotalCostUSD,
-			})
+			summaries = append(summaries, e.ToListSummary())
 		}
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
@@ -88,11 +74,15 @@ func runArchiveList(cmd *cobra.Command, _ []string) error {
 }
 
 func renderArchiveListText(out io.Writer, entries []*archive.Entry) error {
-	fmt.Fprintf(out, "%-36s  %-20s  %-12s  %5s  %s\n", "UUID", "NAME", "STATUS", "MSGS", "STOPPED")
+	fmt.Fprintf(out, "%-36s  %-20s  %-12s  %5s  %10s  %s\n", "UUID", "NAME", "STATUS", "MSGS", "COST", "STOPPED")
 	for _, e := range entries {
 		stopped := e.StoppedAt.Format("2006-01-02 15:04")
-		fmt.Fprintf(out, "%-36s  %-20s  %-12s  %5d  %s\n",
-			e.UUID, truncate(e.Name, 20), e.Status, e.MessageCount, stopped)
+		cost := "-"
+		if e.TotalCostUSD != nil {
+			cost = fmt.Sprintf("$%.4f", *e.TotalCostUSD)
+		}
+		fmt.Fprintf(out, "%-36s  %-20s  %-12s  %5d  %10s  %s\n",
+			e.UUID, truncate(e.Name, 20), e.Status, e.MessageCount, cost, stopped)
 	}
 	return nil
 }
@@ -108,6 +98,10 @@ func runArchiveShow(cmd *cobra.Command, args []string) error {
 	entry, err := archive.Load(paths.ArchivesDir, uuid)
 	if err != nil {
 		return err
+	}
+
+	if !archiveShowFull {
+		entry.Messages = nil
 	}
 
 	out := cmd.OutOrStdout()
@@ -146,8 +140,62 @@ func renderArchiveShowText(out io.Writer, e *archive.Entry) error {
 			fmt.Fprintf(out, "  - %s\n", url)
 		}
 	}
+	if e.ErrorCount > 0 {
+		fmt.Fprintf(out, "Errors:       %d\n", e.ErrorCount)
+	}
 	if e.ErrorMessage != "" {
 		fmt.Fprintf(out, "Error:        %s\n", e.ErrorMessage)
+	}
+	if len(e.ToolCalls) > 0 {
+		fmt.Fprintf(out, "\nTool Calls:\n")
+		type toolCount struct {
+			Name  string
+			Count int
+		}
+		sorted := make([]toolCount, 0, len(e.ToolCalls))
+		for name, count := range e.ToolCalls {
+			sorted = append(sorted, toolCount{name, count})
+		}
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i].Count > sorted[j].Count
+		})
+		fmt.Fprintf(out, "  %-30s  %s\n", "TOOL", "COUNT")
+		for _, tc := range sorted {
+			fmt.Fprintf(out, "  %-30s  %d\n", tc.Name, tc.Count)
+		}
+	}
+	if len(e.ModelUsage) > 0 {
+		fmt.Fprintf(out, "\nModel Usage:\n")
+		type modelCount struct {
+			Model string
+			Count int
+		}
+		sortedModels := make([]modelCount, 0, len(e.ModelUsage))
+		for model, count := range e.ModelUsage {
+			sortedModels = append(sortedModels, modelCount{model, count})
+		}
+		sort.Slice(sortedModels, func(i, j int) bool {
+			return sortedModels[i].Count > sortedModels[j].Count
+		})
+		fmt.Fprintf(out, "  %-30s  %s\n", "MODEL", "COUNT")
+		for _, mc := range sortedModels {
+			fmt.Fprintf(out, "  %-30s  %d\n", mc.Model, mc.Count)
+		}
+	}
+	if len(e.TokenUsage) > 0 {
+		var tokens struct {
+			Input       int `json:"input"`
+			Output      int `json:"output"`
+			CacheCreate int `json:"cache_create"`
+			CacheRead   int `json:"cache_read"`
+		}
+		if json.Unmarshal(e.TokenUsage, &tokens) == nil && (tokens.Input > 0 || tokens.Output > 0) {
+			fmt.Fprintf(out, "\nToken Usage:\n")
+			fmt.Fprintf(out, "  Input:         %d\n", tokens.Input)
+			fmt.Fprintf(out, "  Output:        %d\n", tokens.Output)
+			fmt.Fprintf(out, "  Cache Create:  %d\n", tokens.CacheCreate)
+			fmt.Fprintf(out, "  Cache Read:    %d\n", tokens.CacheRead)
+		}
 	}
 	if e.ResultText != "" {
 		fmt.Fprintf(out, "\n%s\n", e.ResultText)

--- a/cmd/archive_test.go
+++ b/cmd/archive_test.go
@@ -1,0 +1,181 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/klausctl/pkg/archive"
+)
+
+func TestRenderArchiveListText_CostColumn(t *testing.T) {
+	cost := 1.2345
+	entries := []*archive.Entry{
+		{
+			UUID:         "uuid-1",
+			Name:         "dev",
+			Status:       "completed",
+			MessageCount: 10,
+			TotalCostUSD: &cost,
+			StoppedAt:    time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+		},
+		{
+			UUID:         "uuid-2",
+			Name:         "prod",
+			Status:       "error",
+			MessageCount: 5,
+			TotalCostUSD: nil,
+			StoppedAt:    time.Date(2025, 1, 15, 11, 0, 0, 0, time.UTC),
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderArchiveListText(&buf, entries); err != nil {
+		t.Fatalf("renderArchiveListText() error: %v", err)
+	}
+	out := buf.String()
+
+	// Header should contain COST column.
+	if !strings.Contains(out, "COST") {
+		t.Error("expected COST column header")
+	}
+
+	// First entry should show formatted cost.
+	if !strings.Contains(out, "$1.2345") {
+		t.Errorf("expected $1.2345 in output, got:\n%s", out)
+	}
+
+	// Second entry with nil cost should show "-".
+	lines := strings.Split(out, "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 lines, got %d", len(lines))
+	}
+	// The third line (index 2) is the nil-cost entry.
+	if !strings.Contains(lines[2], "  -  ") || strings.Contains(lines[2], "$") {
+		// Check it has "-" somewhere in the cost column area but not "$".
+		// More robust: just check the line contains " - " and not "$".
+		if strings.Contains(lines[2], "$") {
+			t.Errorf("nil cost entry should not contain $, got: %s", lines[2])
+		}
+	}
+}
+
+func TestRenderArchiveShowText_Metrics(t *testing.T) {
+	cost := 0.42
+	tokenUsage, _ := json.Marshal(map[string]int{
+		"input":        1000,
+		"output":       500,
+		"cache_create": 200,
+		"cache_read":   300,
+	})
+
+	entry := &archive.Entry{
+		UUID:         "test-uuid",
+		Name:         "dev",
+		Status:       "completed",
+		Image:        "test:latest",
+		Workspace:    "/tmp/ws",
+		Port:         8080,
+		StartedAt:    time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
+		StoppedAt:    time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+		MessageCount: 42,
+		TotalCostUSD: &cost,
+		ToolCalls:    map[string]int{"Read": 10, "Write": 5, "Bash": 20},
+		ModelUsage:   map[string]int{"opus": 30, "haiku": 12},
+		TokenUsage:   tokenUsage,
+		ErrorCount:   2,
+		ErrorMessage: "something went wrong",
+		ResultText:   "All done.",
+	}
+
+	var buf bytes.Buffer
+	if err := renderArchiveShowText(&buf, entry); err != nil {
+		t.Fatalf("renderArchiveShowText() error: %v", err)
+	}
+	out := buf.String()
+
+	// Check error count is displayed.
+	if !strings.Contains(out, "Errors:       2") {
+		t.Errorf("expected error count, got:\n%s", out)
+	}
+
+	// Check tool calls table.
+	if !strings.Contains(out, "Tool Calls:") {
+		t.Error("expected Tool Calls section")
+	}
+	if !strings.Contains(out, "Bash") {
+		t.Error("expected Bash in tool calls")
+	}
+
+	// Check tool calls sorted by count descending: Bash(20) > Read(10) > Write(5).
+	bashIdx := strings.Index(out, "Bash")
+	readIdx := strings.Index(out, "Read")
+	writeIdx := strings.Index(out, "Write")
+	if bashIdx > readIdx || readIdx > writeIdx {
+		t.Errorf("tool calls not sorted by count descending: Bash@%d, Read@%d, Write@%d", bashIdx, readIdx, writeIdx)
+	}
+
+	// Check model usage table.
+	if !strings.Contains(out, "Model Usage:") {
+		t.Error("expected Model Usage section")
+	}
+	if !strings.Contains(out, "opus") || !strings.Contains(out, "haiku") {
+		t.Error("expected model names in model usage")
+	}
+
+	// Check token usage.
+	if !strings.Contains(out, "Token Usage:") {
+		t.Error("expected Token Usage section")
+	}
+	if !strings.Contains(out, "Input:         1000") {
+		t.Errorf("expected input token count, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Output:        500") {
+		t.Errorf("expected output token count, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Cache Create:  200") {
+		t.Errorf("expected cache create count, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Cache Read:    300") {
+		t.Errorf("expected cache read count, got:\n%s", out)
+	}
+
+	// Check result text still shown.
+	if !strings.Contains(out, "All done.") {
+		t.Error("expected result text")
+	}
+}
+
+func TestRenderArchiveShowText_NoMetrics(t *testing.T) {
+	entry := &archive.Entry{
+		UUID:      "test-uuid",
+		Name:      "dev",
+		Status:    "completed",
+		Image:     "test:latest",
+		Workspace: "/tmp/ws",
+		StartedAt: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
+		StoppedAt: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+	}
+
+	var buf bytes.Buffer
+	if err := renderArchiveShowText(&buf, entry); err != nil {
+		t.Fatalf("renderArchiveShowText() error: %v", err)
+	}
+	out := buf.String()
+
+	// Should not contain metrics sections when data is absent.
+	if strings.Contains(out, "Tool Calls:") {
+		t.Error("should not show Tool Calls when empty")
+	}
+	if strings.Contains(out, "Model Usage:") {
+		t.Error("should not show Model Usage when empty")
+	}
+	if strings.Contains(out, "Token Usage:") {
+		t.Error("should not show Token Usage when empty")
+	}
+	if strings.Contains(out, "Errors:") {
+		t.Error("should not show Errors when zero")
+	}
+}

--- a/internal/tools/instance/archive.go
+++ b/internal/tools/instance/archive.go
@@ -24,19 +24,11 @@ func registerArchiveShow(s *mcpserver.MCPServer, sc *server.ServerContext) {
 	tool := mcp.NewTool("klaus_archive_show",
 		mcp.WithDescription("Show a single archived instance transcript by UUID"),
 		mcp.WithString("uuid", mcp.Required(), mcp.Description("Archive UUID")),
+		mcp.WithBoolean("full", mcp.Description("Include the full messages array in the response (default: false)")),
 	)
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleArchiveShow(ctx, req, sc)
 	})
-}
-
-type archiveListEntry struct {
-	UUID         string   `json:"uuid"`
-	Name         string   `json:"name"`
-	Status       string   `json:"status"`
-	StoppedAt    string   `json:"stopped_at"`
-	MessageCount int      `json:"message_count"`
-	TotalCostUSD *float64 `json:"total_cost_usd,omitempty"`
 }
 
 func handleArchiveList(_ context.Context, _ mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
@@ -45,16 +37,9 @@ func handleArchiveList(_ context.Context, _ mcp.CallToolRequest, sc *server.Serv
 		return mcp.NewToolResultError(fmt.Sprintf("loading archives: %v", err)), nil
 	}
 
-	list := make([]archiveListEntry, 0, len(entries))
+	list := make([]archive.ListSummary, 0, len(entries))
 	for _, e := range entries {
-		list = append(list, archiveListEntry{
-			UUID:         e.UUID,
-			Name:         e.Name,
-			Status:       e.Status,
-			StoppedAt:    e.StoppedAt.Format("2006-01-02T15:04:05Z07:00"),
-			MessageCount: e.MessageCount,
-			TotalCostUSD: e.TotalCostUSD,
-		})
+		list = append(list, e.ToListSummary())
 	}
 
 	return server.JSONResult(list)
@@ -66,9 +51,15 @@ func handleArchiveShow(_ context.Context, req mcp.CallToolRequest, sc *server.Se
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	full := req.GetBool("full", false)
+
 	entry, err := archive.Load(sc.Paths.ArchivesDir, uuid)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("loading archive: %v", err)), nil
+	}
+
+	if !full {
+		entry.Messages = nil
 	}
 
 	return server.JSONResult(entry)

--- a/internal/tools/instance/archive_test.go
+++ b/internal/tools/instance/archive_test.go
@@ -53,7 +53,7 @@ func TestHandleArchiveListWithEntries(t *testing.T) {
 	}
 
 	text := extractResultText(t, result)
-	var list []archiveListEntry
+	var list []archive.ListSummary
 	if err := json.Unmarshal([]byte(text), &list); err != nil {
 		t.Fatalf("expected JSON array, got: %s", text)
 	}
@@ -98,6 +98,69 @@ func TestHandleArchiveShowByUUID(t *testing.T) {
 	}
 	if loaded.ResultText != "All done." {
 		t.Errorf("ResultText = %q, want %q", loaded.ResultText, "All done.")
+	}
+}
+
+func TestHandleArchiveShowOmitsMessagesByDefault(t *testing.T) {
+	sc := testServerContext(t)
+
+	entry := &archive.Entry{
+		UUID:         "msg-uuid",
+		Name:         "test",
+		Status:       "completed",
+		MessageCount: 5,
+		Messages:     json.RawMessage(`[{"role":"user","content":"hello"}]`),
+		StoppedAt:    time.Now(),
+	}
+	if err := archive.Save(sc.Paths.ArchivesDir, entry); err != nil {
+		t.Fatalf("saving entry: %v", err)
+	}
+
+	// Without full=true, messages should be omitted.
+	req := callToolRequest(map[string]any{"uuid": "msg-uuid"})
+	result, err := handleArchiveShow(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractResultText(t, result)
+	var loaded map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(text), &loaded); err != nil {
+		t.Fatalf("expected JSON object, got: %s", text)
+	}
+	if _, ok := loaded["messages"]; ok {
+		t.Error("messages should be omitted when full is not set")
+	}
+}
+
+func TestHandleArchiveShowIncludesMessagesWhenFull(t *testing.T) {
+	sc := testServerContext(t)
+
+	entry := &archive.Entry{
+		UUID:         "full-uuid",
+		Name:         "test",
+		Status:       "completed",
+		MessageCount: 5,
+		Messages:     json.RawMessage(`[{"role":"user","content":"hello"}]`),
+		StoppedAt:    time.Now(),
+	}
+	if err := archive.Save(sc.Paths.ArchivesDir, entry); err != nil {
+		t.Fatalf("saving entry: %v", err)
+	}
+
+	req := callToolRequest(map[string]any{"uuid": "full-uuid", "full": true})
+	result, err := handleArchiveShow(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractResultText(t, result)
+	var loaded map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(text), &loaded); err != nil {
+		t.Fatalf("expected JSON object, got: %s", text)
+	}
+	if _, ok := loaded["messages"]; !ok {
+		t.Error("messages should be included when full=true")
 	}
 }
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -180,6 +180,29 @@ func EntryFromResult(inst *instance.Instance, resultJSON string) (*Entry, error)
 	return entry, nil
 }
 
+// ListSummary is the shared list-summary type used by both the CLI and MCP
+// tool for archive list responses.
+type ListSummary struct {
+	UUID         string   `json:"uuid"`
+	Name         string   `json:"name"`
+	Status       string   `json:"status"`
+	StoppedAt    string   `json:"stopped_at"`
+	MessageCount int      `json:"message_count"`
+	TotalCostUSD *float64 `json:"total_cost_usd,omitempty"`
+}
+
+// ToListSummary converts an Entry to a ListSummary for list responses.
+func (e *Entry) ToListSummary() ListSummary {
+	return ListSummary{
+		UUID:         e.UUID,
+		Name:         e.Name,
+		Status:       e.Status,
+		StoppedAt:    e.StoppedAt.Format("2006-01-02T15:04:05Z07:00"),
+		MessageCount: e.MessageCount,
+		TotalCostUSD: e.TotalCostUSD,
+	}
+}
+
 // --- JSON decode helpers ---
 
 func decodeString(raw map[string]json.RawMessage, key string, dst *string) {

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -231,6 +231,38 @@ func TestEntryFromResult_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestToListSummary(t *testing.T) {
+	cost := 1.23
+	entry := &Entry{
+		UUID:         "summary-uuid",
+		Name:         "dev",
+		Status:       "completed",
+		StoppedAt:    time.Date(2025, 6, 15, 10, 30, 0, 0, time.UTC),
+		MessageCount: 42,
+		TotalCostUSD: &cost,
+	}
+
+	s := entry.ToListSummary()
+	if s.UUID != "summary-uuid" {
+		t.Errorf("UUID = %q, want %q", s.UUID, "summary-uuid")
+	}
+	if s.Name != "dev" {
+		t.Errorf("Name = %q, want %q", s.Name, "dev")
+	}
+	if s.Status != "completed" {
+		t.Errorf("Status = %q, want %q", s.Status, "completed")
+	}
+	if s.MessageCount != 42 {
+		t.Errorf("MessageCount = %d, want %d", s.MessageCount, 42)
+	}
+	if s.TotalCostUSD == nil || *s.TotalCostUSD != 1.23 {
+		t.Errorf("TotalCostUSD = %v, want 1.23", s.TotalCostUSD)
+	}
+	if s.StoppedAt != "2025-06-15T10:30:00Z" {
+		t.Errorf("StoppedAt = %q, want %q", s.StoppedAt, "2025-06-15T10:30:00Z")
+	}
+}
+
 func mustMarshal(t *testing.T, v any) string {
 	t.Helper()
 	data, err := json.Marshal(v)


### PR DESCRIPTION
## Summary

- feat: archive CLI/MCP improvements (#125)

## Related issues

Relates to #125

## Commits

### feat: archive CLI/MCP improvements (#125)

- Add --full flag to `archive show` CLI and `full` boolean param to the
  `klaus_archive_show` MCP tool; omit messages by default.
- Render tool_calls, model_usage, token_usage, and error_count in
  `archive show` text output.
- Add COST column to `archive list` text output.
- Deduplicate list-summary struct into `pkg/archive.ListSummary`, used
  by both CLI and MCP.

Closes #125

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

