### PR TITLE
Feat: extend stats command with richer summaries, list/top subcommands, filters, and complexity insi

### DIFF
--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -36,6 +36,9 @@ var statsSummaryCmd = &cobra.Command{
 
 var statsSpendBy string
 var statsSpendWeeks int
+var statsSpendRepo string
+var statsSpendOutcome string
+var statsSpendComplexity string
 
 var statsSpendCmd = &cobra.Command{
 	Use:   "spend",
@@ -47,12 +50,42 @@ var statsSpendCmd = &cobra.Command{
 // --- trends ---
 
 var statsTrendsWeeks int
+var statsTrendsRepo string
+var statsTrendsOutcome string
+var statsTrendsComplexity string
 
 var statsTrendsCmd = &cobra.Command{
 	Use:   "trends",
 	Short: "Week-over-week trends",
 	Args:  cobra.NoArgs,
 	RunE:  runStatsTrends,
+}
+
+// --- list ---
+
+var statsListRepo string
+var statsListOutcome string
+var statsListComplexity string
+var statsListSort string
+var statsListLimit int
+
+var statsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Tabular view of individual archive entries",
+	Args:  cobra.NoArgs,
+	RunE:  runStatsList,
+}
+
+// --- top ---
+
+var statsTopBy string
+var statsTopLimit int
+
+var statsTopCmd = &cobra.Command{
+	Use:   "top",
+	Short: "Show outlier runs (most expensive, longest, chattiest)",
+	Args:  cobra.NoArgs,
+	RunE:  runStatsTop,
 }
 
 func init() {
@@ -64,12 +97,29 @@ func init() {
 
 	statsSpendCmd.Flags().StringVar(&statsSpendBy, "by", "week", "group by: week, repo, complexity")
 	statsSpendCmd.Flags().IntVar(&statsSpendWeeks, "weeks", 8, "limit to last N weeks")
+	statsSpendCmd.Flags().StringVar(&statsSpendRepo, "repo", "", "filter by repo tag")
+	statsSpendCmd.Flags().StringVar(&statsSpendOutcome, "outcome", "", "filter by outcome tag (success, partial, failed)")
+	statsSpendCmd.Flags().StringVar(&statsSpendComplexity, "complexity", "", "filter by complexity tag")
 
 	statsTrendsCmd.Flags().IntVar(&statsTrendsWeeks, "weeks", 8, "limit to last N weeks")
+	statsTrendsCmd.Flags().StringVar(&statsTrendsRepo, "repo", "", "filter by repo tag")
+	statsTrendsCmd.Flags().StringVar(&statsTrendsOutcome, "outcome", "", "filter by outcome tag (success, partial, failed)")
+	statsTrendsCmd.Flags().StringVar(&statsTrendsComplexity, "complexity", "", "filter by complexity tag")
+
+	statsListCmd.Flags().StringVar(&statsListRepo, "repo", "", "filter by repo tag")
+	statsListCmd.Flags().StringVar(&statsListOutcome, "outcome", "", "filter by outcome tag (success, partial, failed)")
+	statsListCmd.Flags().StringVar(&statsListComplexity, "complexity", "", "filter by complexity tag")
+	statsListCmd.Flags().StringVar(&statsListSort, "sort", "date", "sort by: date, cost, messages")
+	statsListCmd.Flags().IntVar(&statsListLimit, "limit", 0, "limit number of rows (0 = all)")
+
+	statsTopCmd.Flags().StringVar(&statsTopBy, "by", "cost", "sort by: cost, messages, duration")
+	statsTopCmd.Flags().IntVar(&statsTopLimit, "limit", 10, "number of top entries to show")
 
 	statsCmd.AddCommand(statsSummaryCmd)
 	statsCmd.AddCommand(statsSpendCmd)
 	statsCmd.AddCommand(statsTrendsCmd)
+	statsCmd.AddCommand(statsListCmd)
+	statsCmd.AddCommand(statsTopCmd)
 	rootCmd.AddCommand(statsCmd)
 }
 
@@ -115,14 +165,53 @@ func runStatsSummary(cmd *cobra.Command, _ []string) error {
 }
 
 func renderSummaryText(out io.Writer, s *archive.SummaryStats) error {
-	fmt.Fprintf(out, "Total runs:      %d\n", s.TotalRuns)
-	fmt.Fprintf(out, "Success:         %d (%g%%)\n", s.Success, s.SuccessPct)
-	fmt.Fprintf(out, "Partial:         %d (%g%%)\n", s.Partial, s.PartialPct)
+	fmt.Fprintf(out, "Total runs:      %-8d  First attempt:   %d/%d (%g%%)\n",
+		s.TotalRuns, s.FirstAttempt, s.TotalRuns, s.FirstAttemptPct)
+	fmt.Fprintf(out, "Success:         %d (%g%%)", s.Success, s.SuccessPct)
+	if s.ScopeTotal > 0 {
+		fmt.Fprintf(out, "  Scope adherence: %d/%d (%g%%)", s.ScopeAdherence, s.ScopeTotal, s.ScopeAdherencePct)
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "Partial:         %d (%g%%)", s.Partial, s.PartialPct)
+	if s.ReworkNone > 0 || s.ReworkMinor > 0 || s.ReworkMajor > 0 {
+		fmt.Fprintf(out, "  Rework: none %d, minor %d, major %d", s.ReworkNone, s.ReworkMinor, s.ReworkMajor)
+	}
+	fmt.Fprintln(out)
 	fmt.Fprintf(out, "Failure:         %d (%g%%)\n", s.Failure, s.FailurePct)
-	fmt.Fprintf(out, "Total cost:      $%.2f\n", s.TotalCostUSD)
-	fmt.Fprintf(out, "Avg cost/run:    $%.2f\n", s.AvgCostUSD)
-	fmt.Fprintf(out, "Avg messages:    %d\n", s.AvgMessages)
-	fmt.Fprintf(out, "Median duration: %s\n", s.MedianDuration)
+
+	fmt.Fprintln(out)
+	if s.TotalRuns > 0 {
+		fmt.Fprintf(out, "Cost:  $%.2f total, $%.2f avg", s.TotalCostUSD, s.AvgCostUSD)
+		if s.MinCost != s.MaxCost {
+			fmt.Fprintf(out, ", $%.2f-$%.2f range", s.MinCost, s.MaxCost)
+		}
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "Msgs:  %d avg", s.AvgMessages)
+		if s.MinMessages != s.MaxMessages {
+			fmt.Fprintf(out, ", %d-%d range", s.MinMessages, s.MaxMessages)
+		}
+		fmt.Fprintln(out)
+		if s.MedianDuration != "" {
+			fmt.Fprintf(out, "Time:  %s median", s.MedianDuration)
+			if s.MinDuration != s.MaxDuration {
+				fmt.Fprintf(out, ", %s-%s range", s.MinDuration, s.MaxDuration)
+			}
+			fmt.Fprintln(out)
+		}
+	}
+
+	if len(s.ComplexityBreakdown) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Complexity:")
+		for _, cg := range s.ComplexityBreakdown {
+			runWord := "runs"
+			if cg.Runs == 1 {
+				runWord = "run "
+			}
+			fmt.Fprintf(out, "  %-10s %d %s  $%.2f avg  %g%% success\n",
+				cg.Level, cg.Runs, runWord, cg.AvgCost, cg.SuccessPct)
+		}
+	}
 	return nil
 }
 
@@ -143,7 +232,13 @@ func runStatsSpend(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	groups := archive.ComputeSpend(entries, statsSpendBy, statsSpendWeeks)
+	filters := archive.SummaryFilters{
+		Repo:       statsSpendRepo,
+		Outcome:    statsSpendOutcome,
+		Complexity: statsSpendComplexity,
+	}
+
+	groups := archive.ComputeSpend(entries, statsSpendBy, statsSpendWeeks, filters)
 
 	out := cmd.OutOrStdout()
 	if statsOutput == "json" {
@@ -156,10 +251,10 @@ func runStatsSpend(cmd *cobra.Command, _ []string) error {
 }
 
 func renderSpendText(out io.Writer, groups []archive.SpendGroup) error {
-	fmt.Fprintf(out, "%-20s  %5s  %10s  %10s\n", "GROUP", "RUNS", "TOTAL", "AVG")
+	fmt.Fprintf(out, "%-20s  %5s  %7s  %10s  %10s\n", "GROUP", "RUNS", "%TOTAL", "TOTAL", "AVG")
 	for _, g := range groups {
-		fmt.Fprintf(out, "%-20s  %5d  %10s  %10s\n",
-			truncate(g.Group, 20), g.Runs,
+		fmt.Fprintf(out, "%-20s  %5d  %6g%%  %10s  %10s\n",
+			truncate(g.Group, 20), g.Runs, g.PctOfTotal,
 			fmt.Sprintf("$%.2f", g.TotalCost),
 			fmt.Sprintf("$%.2f", g.AvgCost))
 	}
@@ -177,7 +272,13 @@ func runStatsTrends(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	trends := archive.ComputeTrends(entries, statsTrendsWeeks)
+	filters := archive.SummaryFilters{
+		Repo:       statsTrendsRepo,
+		Outcome:    statsTrendsOutcome,
+		Complexity: statsTrendsComplexity,
+	}
+
+	trends := archive.ComputeTrends(entries, statsTrendsWeeks, filters)
 
 	out := cmd.OutOrStdout()
 	if statsOutput == "json" {
@@ -190,11 +291,102 @@ func runStatsTrends(cmd *cobra.Command, _ []string) error {
 }
 
 func renderTrendsText(out io.Writer, trends []archive.TrendWeek) error {
-	fmt.Fprintf(out, "%-12s  %5s  %8s  %10s  %8s\n", "WEEK", "RUNS", "SUCCESS%", "AVG COST", "AVG MSGS")
+	fmt.Fprintf(out, "%-12s  %5s  %8s  %5s  %10s  %10s  %8s  %7s  %9s\n",
+		"WEEK", "RUNS", "SUCCESS%", "1ST%", "AVG COST", "TOTAL COST", "AVG MSGS", "AVG DUR", "AVG CMPLX")
 	for _, tw := range trends {
-		fmt.Fprintf(out, "%-12s  %5d  %7g%%  %10s  %8d\n",
-			tw.Week, tw.Runs, tw.SuccessPct,
-			fmt.Sprintf("$%.2f", tw.AvgCostUSD), tw.AvgMessages)
+		cmplx := ""
+		if tw.AvgComplexity > 0 {
+			cmplx = fmt.Sprintf("%.1f", tw.AvgComplexity)
+		}
+		dur := tw.AvgDuration
+		if dur == "" {
+			dur = "-"
+		}
+		fmt.Fprintf(out, "%-12s  %5d  %7g%%  %4g%%  %10s  %10s  %8d  %7s  %9s\n",
+			tw.Week, tw.Runs, tw.SuccessPct, tw.FirstAttemptPct,
+			fmt.Sprintf("$%.2f", tw.AvgCostUSD),
+			fmt.Sprintf("$%.2f", tw.TotalCostUSD),
+			tw.AvgMessages, dur, cmplx)
 	}
 	return nil
+}
+
+func runStatsList(cmd *cobra.Command, _ []string) error {
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+
+	entries, err := archive.LoadAll(paths.ArchivesDir)
+	if err != nil {
+		return err
+	}
+
+	switch statsListSort {
+	case "date", "cost", "messages":
+	default:
+		return fmt.Errorf("invalid --sort value %q: use date, cost, or messages", statsListSort)
+	}
+
+	filters := archive.SummaryFilters{
+		Repo:       statsListRepo,
+		Outcome:    statsListOutcome,
+		Complexity: statsListComplexity,
+	}
+
+	list := archive.ComputeList(entries, filters, statsListSort, statsListLimit)
+
+	out := cmd.OutOrStdout()
+	if statsOutput == "json" {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(list)
+	}
+
+	return renderListText(out, list)
+}
+
+func renderListText(out io.Writer, list []archive.ListEntry) error {
+	fmt.Fprintf(out, "%-12s  %-26s  %-22s  %-14s  %-8s  %7s  %5s  %8s  %-10s\n",
+		"DATE", "NAME", "REPO", "ISSUE", "OUTCOME", "COST", "MSGS", "DURATION", "COMPLEXITY")
+	for _, le := range list {
+		dur := le.Duration
+		if dur == "" {
+			dur = "-"
+		}
+		fmt.Fprintf(out, "%-12s  %-26s  %-22s  %-14s  %-8s  %7s  %5d  %8s  %-10s\n",
+			le.Date, truncate(le.Name, 26), truncate(le.Repo, 22), truncate(le.Issue, 14),
+			le.Outcome, fmt.Sprintf("$%.2f", le.Cost), le.Messages, dur, le.Complexity)
+	}
+	return nil
+}
+
+func runStatsTop(cmd *cobra.Command, _ []string) error {
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+
+	entries, err := archive.LoadAll(paths.ArchivesDir)
+	if err != nil {
+		return err
+	}
+
+	sortBy := statsTopBy
+	switch sortBy {
+	case "cost", "messages", "duration":
+	default:
+		return fmt.Errorf("invalid --by value %q: use cost, messages, or duration", sortBy)
+	}
+
+	list := archive.ComputeList(entries, archive.SummaryFilters{}, sortBy, statsTopLimit)
+
+	out := cmd.OutOrStdout()
+	if statsOutput == "json" {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(list)
+	}
+
+	return renderListText(out, list)
 }

--- a/internal/tools/instance/stats.go
+++ b/internal/tools/instance/stats.go
@@ -30,6 +30,9 @@ func registerStatsSpend(s *mcpserver.MCPServer, sc *server.ServerContext) {
 		mcp.WithDescription("Cost breakdown grouped by week, repo, or complexity"),
 		mcp.WithString("group_by", mcp.Description("Group by: week (default), repo, or complexity")),
 		mcp.WithNumber("weeks", mcp.Description("Limit to last N weeks (default: 8, max: 520)")),
+		mcp.WithString("repo", mcp.Description("Filter by repo tag")),
+		mcp.WithString("outcome", mcp.Description("Filter by outcome tag: success, partial, or failed")),
+		mcp.WithString("complexity", mcp.Description("Filter by complexity tag")),
 	)
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleStatsSpend(ctx, req, sc)
@@ -38,11 +41,39 @@ func registerStatsSpend(s *mcpserver.MCPServer, sc *server.ServerContext) {
 
 func registerStatsTrends(s *mcpserver.MCPServer, sc *server.ServerContext) {
 	tool := mcp.NewTool("klaus_stats_trends",
-		mcp.WithDescription("Week-over-week trends: runs, success rate, avg cost, avg messages"),
+		mcp.WithDescription("Week-over-week trends: runs, success rate, first-attempt rate, avg cost, total cost, avg messages, avg duration, avg complexity"),
 		mcp.WithNumber("weeks", mcp.Description("Limit to last N weeks (default: 8, max: 520)")),
+		mcp.WithString("repo", mcp.Description("Filter by repo tag")),
+		mcp.WithString("outcome", mcp.Description("Filter by outcome tag: success, partial, or failed")),
+		mcp.WithString("complexity", mcp.Description("Filter by complexity tag")),
 	)
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleStatsTrends(ctx, req, sc)
+	})
+}
+
+func registerStatsList(s *mcpserver.MCPServer, sc *server.ServerContext) {
+	tool := mcp.NewTool("klaus_stats_list",
+		mcp.WithDescription("Tabular view of individual archive entries with filtering and sorting"),
+		mcp.WithString("repo", mcp.Description("Filter by repo tag")),
+		mcp.WithString("outcome", mcp.Description("Filter by outcome tag: success, partial, or failed")),
+		mcp.WithString("complexity", mcp.Description("Filter by complexity tag")),
+		mcp.WithString("sort_by", mcp.Description("Sort by: date (default), cost, or messages")),
+		mcp.WithNumber("limit", mcp.Description("Limit number of rows (0 = all)")),
+	)
+	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleStatsList(ctx, req, sc)
+	})
+}
+
+func registerStatsTop(s *mcpserver.MCPServer, sc *server.ServerContext) {
+	tool := mcp.NewTool("klaus_stats_top",
+		mcp.WithDescription("Show outlier runs sorted by cost, messages, or duration"),
+		mcp.WithString("sort_by", mcp.Description("Sort by: cost (default), messages, or duration")),
+		mcp.WithNumber("limit", mcp.Description("Number of top entries (default: 10)")),
+	)
+	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleStatsTop(ctx, req, sc)
 	})
 }
 
@@ -95,7 +126,13 @@ func handleStatsSpend(_ context.Context, req mcp.CallToolRequest, sc *server.Ser
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	groups := archive.ComputeSpend(entries, groupBy, weeks)
+	filters := archive.SummaryFilters{
+		Repo:       req.GetString("repo", ""),
+		Outcome:    req.GetString("outcome", ""),
+		Complexity: req.GetString("complexity", ""),
+	}
+
+	groups := archive.ComputeSpend(entries, groupBy, weeks, filters)
 	return server.JSONResult(groups)
 }
 
@@ -110,8 +147,61 @@ func handleStatsTrends(_ context.Context, req mcp.CallToolRequest, sc *server.Se
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	trends := archive.ComputeTrends(entries, weeks)
+	filters := archive.SummaryFilters{
+		Repo:       req.GetString("repo", ""),
+		Outcome:    req.GetString("outcome", ""),
+		Complexity: req.GetString("complexity", ""),
+	}
+
+	trends := archive.ComputeTrends(entries, weeks, filters)
 	return server.JSONResult(trends)
+}
+
+func handleStatsList(_ context.Context, req mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
+	entries, err := archive.LoadAll(sc.Paths.ArchivesDir)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("loading archives: %v", err)), nil
+	}
+
+	sortBy := req.GetString("sort_by", "date")
+	switch sortBy {
+	case "date", "cost", "messages":
+	default:
+		return mcp.NewToolResultError(fmt.Sprintf("invalid sort_by %q: use date, cost, or messages", sortBy)), nil
+	}
+
+	limit := int(math.Round(req.GetFloat("limit", 0)))
+
+	filters := archive.SummaryFilters{
+		Repo:       req.GetString("repo", ""),
+		Outcome:    req.GetString("outcome", ""),
+		Complexity: req.GetString("complexity", ""),
+	}
+
+	list := archive.ComputeList(entries, filters, sortBy, limit)
+	return server.JSONResult(list)
+}
+
+func handleStatsTop(_ context.Context, req mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
+	entries, err := archive.LoadAll(sc.Paths.ArchivesDir)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("loading archives: %v", err)), nil
+	}
+
+	sortBy := req.GetString("sort_by", "cost")
+	switch sortBy {
+	case "cost", "messages", "duration":
+	default:
+		return mcp.NewToolResultError(fmt.Sprintf("invalid sort_by %q: use cost, messages, or duration", sortBy)), nil
+	}
+
+	limit := int(math.Round(req.GetFloat("limit", 10)))
+	if limit < 1 {
+		limit = 10
+	}
+
+	list := archive.ComputeList(entries, archive.SummaryFilters{}, sortBy, limit)
+	return server.JSONResult(list)
 }
 
 // parseWeeks extracts and validates the weeks parameter from an MCP request.

--- a/internal/tools/instance/stats_test.go
+++ b/internal/tools/instance/stats_test.go
@@ -15,6 +15,7 @@ func saveTestEntries(t *testing.T, sc *server.ServerContext) {
 	now := time.Now()
 	cost1 := 1.50
 	cost2 := 3.00
+	cost3 := 5.00
 
 	entries := []*archive.Entry{
 		{
@@ -24,7 +25,14 @@ func saveTestEntries(t *testing.T, sc *server.ServerContext) {
 			StoppedAt:    now.Add(-20 * time.Minute),
 			MessageCount: 100,
 			TotalCostUSD: &cost1,
-			Tags:         map[string]string{"outcome": "success", "repo": "frontend"},
+			Tags: map[string]string{
+				"outcome":       "success",
+				"repo":          "frontend",
+				"complexity":    "simple",
+				"first_attempt": "true",
+				"scope":         "adhered",
+				"rework":        "none",
+			},
 		},
 		{
 			UUID:         "s2",
@@ -33,7 +41,30 @@ func saveTestEntries(t *testing.T, sc *server.ServerContext) {
 			StoppedAt:    now.Add(-50 * time.Minute),
 			MessageCount: 200,
 			TotalCostUSD: &cost2,
-			Tags:         map[string]string{"outcome": "failed", "repo": "backend"},
+			Tags: map[string]string{
+				"outcome":       "failed",
+				"repo":          "backend",
+				"complexity":    "complex",
+				"first_attempt": "false",
+				"rework":        "minor",
+				"issue":         "backend#42",
+			},
+		},
+		{
+			UUID:         "s3",
+			Name:         "run-3",
+			StartedAt:    now.Add(-90 * time.Minute),
+			StoppedAt:    now.Add(-80 * time.Minute),
+			MessageCount: 300,
+			TotalCostUSD: &cost3,
+			Tags: map[string]string{
+				"outcome":       "success",
+				"repo":          "frontend",
+				"complexity":    "moderate",
+				"first_attempt": "true",
+				"scope":         "adhered",
+				"rework":        "none",
+			},
 		},
 	}
 	for _, e := range entries {
@@ -58,14 +89,27 @@ func TestHandleStatsSummary(t *testing.T) {
 	if err := json.Unmarshal([]byte(text), &stats); err != nil {
 		t.Fatalf("expected JSON object, got: %s", text)
 	}
-	if stats.TotalRuns != 2 {
-		t.Errorf("TotalRuns = %d, want 2", stats.TotalRuns)
+	if stats.TotalRuns != 3 {
+		t.Errorf("TotalRuns = %d, want 3", stats.TotalRuns)
 	}
-	if stats.Success != 1 {
-		t.Errorf("Success = %d, want 1", stats.Success)
+	if stats.Success != 2 {
+		t.Errorf("Success = %d, want 2", stats.Success)
 	}
 	if stats.Failure != 1 {
 		t.Errorf("Failure = %d, want 1", stats.Failure)
+	}
+	// Enriched fields
+	if stats.FirstAttempt != 2 {
+		t.Errorf("FirstAttempt = %d, want 2", stats.FirstAttempt)
+	}
+	if stats.ReworkNone != 2 {
+		t.Errorf("ReworkNone = %d, want 2", stats.ReworkNone)
+	}
+	if stats.ReworkMinor != 1 {
+		t.Errorf("ReworkMinor = %d, want 1", stats.ReworkMinor)
+	}
+	if len(stats.ComplexityBreakdown) != 3 {
+		t.Errorf("ComplexityBreakdown length = %d, want 3", len(stats.ComplexityBreakdown))
 	}
 }
 
@@ -84,8 +128,8 @@ func TestHandleStatsSummaryWithFilters(t *testing.T) {
 	if err := json.Unmarshal([]byte(text), &stats); err != nil {
 		t.Fatalf("expected JSON object, got: %s", text)
 	}
-	if stats.TotalRuns != 1 {
-		t.Errorf("TotalRuns = %d, want 1", stats.TotalRuns)
+	if stats.TotalRuns != 2 {
+		t.Errorf("TotalRuns = %d, want 2", stats.TotalRuns)
 	}
 }
 
@@ -137,6 +181,54 @@ func TestHandleStatsSpend(t *testing.T) {
 	if len(groups) != 2 {
 		t.Errorf("expected 2 groups, got %d", len(groups))
 	}
+	// Verify PctOfTotal is present
+	for _, g := range groups {
+		if g.PctOfTotal <= 0 {
+			t.Errorf("group %q PctOfTotal = %g, want > 0", g.Group, g.PctOfTotal)
+		}
+	}
+}
+
+func TestHandleStatsSpendByComplexity(t *testing.T) {
+	sc := testServerContext(t)
+	saveTestEntries(t, sc)
+
+	req := callToolRequest(map[string]any{"group_by": "complexity"})
+	result, err := handleStatsSpend(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractResultText(t, result)
+	var groups []archive.SpendGroup
+	if err := json.Unmarshal([]byte(text), &groups); err != nil {
+		t.Fatalf("expected JSON array, got: %s", text)
+	}
+	// 3 entries with simple, complex, moderate
+	if len(groups) != 3 {
+		t.Errorf("expected 3 groups, got %d", len(groups))
+	}
+}
+
+func TestHandleStatsSpendWithFilters(t *testing.T) {
+	sc := testServerContext(t)
+	saveTestEntries(t, sc)
+
+	req := callToolRequest(map[string]any{"group_by": "repo", "outcome": "success"})
+	result, err := handleStatsSpend(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractResultText(t, result)
+	var groups []archive.SpendGroup
+	if err := json.Unmarshal([]byte(text), &groups); err != nil {
+		t.Fatalf("expected JSON array, got: %s", text)
+	}
+	// Only success entries: both are frontend
+	if len(groups) != 1 {
+		t.Errorf("expected 1 group, got %d", len(groups))
+	}
 }
 
 func TestHandleStatsSpendInvalidGroupBy(t *testing.T) {
@@ -166,7 +258,7 @@ func TestHandleStatsSpendDefaultGroupBy(t *testing.T) {
 	if err := json.Unmarshal([]byte(text), &groups); err != nil {
 		t.Fatalf("expected JSON array, got: %s", text)
 	}
-	// Both entries are from today, so 1 week group.
+	// All entries are from today, so 1 week group.
 	if len(groups) != 1 {
 		t.Errorf("expected 1 week group, got %d", len(groups))
 	}
@@ -209,9 +301,42 @@ func TestHandleStatsTrends(t *testing.T) {
 	if err := json.Unmarshal([]byte(text), &trends); err != nil {
 		t.Fatalf("expected JSON array, got: %s", text)
 	}
-	// Both entries are from the same week.
+	// All entries are from the same week.
 	if len(trends) != 1 {
 		t.Errorf("expected 1 trend week, got %d", len(trends))
+	}
+	if trends[0].Runs != 3 {
+		t.Errorf("runs = %d, want 3", trends[0].Runs)
+	}
+	// Enriched fields
+	if trends[0].TotalCostUSD == 0 {
+		t.Error("TotalCostUSD should be > 0")
+	}
+	if trends[0].AvgDuration == "" {
+		t.Error("AvgDuration should not be empty")
+	}
+	if trends[0].AvgComplexity == 0 {
+		t.Error("AvgComplexity should be > 0")
+	}
+}
+
+func TestHandleStatsTrendsWithFilters(t *testing.T) {
+	sc := testServerContext(t)
+	saveTestEntries(t, sc)
+
+	req := callToolRequest(map[string]any{"repo": "frontend"})
+	result, err := handleStatsTrends(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractResultText(t, result)
+	var trends []archive.TrendWeek
+	if err := json.Unmarshal([]byte(text), &trends); err != nil {
+		t.Fatalf("expected JSON array, got: %s", text)
+	}
+	if len(trends) != 1 {
+		t.Fatalf("expected 1 trend week, got %d", len(trends))
 	}
 	if trends[0].Runs != 2 {
 		t.Errorf("runs = %d, want 2", trends[0].Runs)
@@ -235,4 +360,138 @@ func TestHandleStatsTrendsEmpty(t *testing.T) {
 	if len(trends) != 0 {
 		t.Errorf("expected 0 trends, got %d", len(trends))
 	}
+}
+
+func TestHandleStatsList(t *testing.T) {
+	sc := testServerContext(t)
+	saveTestEntries(t, sc)
+
+	req := callToolRequest(nil)
+	result, err := handleStatsList(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractResultText(t, result)
+	var list []archive.ListEntry
+	if err := json.Unmarshal([]byte(text), &list); err != nil {
+		t.Fatalf("expected JSON array, got: %s", text)
+	}
+	if len(list) != 3 {
+		t.Errorf("expected 3 entries, got %d", len(list))
+	}
+}
+
+func TestHandleStatsListWithFilters(t *testing.T) {
+	sc := testServerContext(t)
+	saveTestEntries(t, sc)
+
+	req := callToolRequest(map[string]any{"repo": "frontend", "sort_by": "cost"})
+	result, err := handleStatsList(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractResultText(t, result)
+	var list []archive.ListEntry
+	if err := json.Unmarshal([]byte(text), &list); err != nil {
+		t.Fatalf("expected JSON array, got: %s", text)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(list))
+	}
+	// Sorted by cost descending
+	if len(list) >= 2 && list[0].Cost < list[1].Cost {
+		t.Error("expected list sorted by cost descending")
+	}
+}
+
+func TestHandleStatsListWithLimit(t *testing.T) {
+	sc := testServerContext(t)
+	saveTestEntries(t, sc)
+
+	req := callToolRequest(map[string]any{"limit": float64(1)})
+	result, err := handleStatsList(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractResultText(t, result)
+	var list []archive.ListEntry
+	if err := json.Unmarshal([]byte(text), &list); err != nil {
+		t.Fatalf("expected JSON array, got: %s", text)
+	}
+	if len(list) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(list))
+	}
+}
+
+func TestHandleStatsListInvalidSortBy(t *testing.T) {
+	sc := testServerContext(t)
+
+	req := callToolRequest(map[string]any{"sort_by": "invalid"})
+	result, err := handleStatsList(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertIsError(t, result)
+}
+
+func TestHandleStatsTop(t *testing.T) {
+	sc := testServerContext(t)
+	saveTestEntries(t, sc)
+
+	req := callToolRequest(nil)
+	result, err := handleStatsTop(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractResultText(t, result)
+	var list []archive.ListEntry
+	if err := json.Unmarshal([]byte(text), &list); err != nil {
+		t.Fatalf("expected JSON array, got: %s", text)
+	}
+	if len(list) != 3 {
+		t.Errorf("expected 3 entries, got %d", len(list))
+	}
+	// Default sort by cost descending
+	if len(list) >= 2 && list[0].Cost < list[1].Cost {
+		t.Error("expected list sorted by cost descending")
+	}
+}
+
+func TestHandleStatsTopByMessages(t *testing.T) {
+	sc := testServerContext(t)
+	saveTestEntries(t, sc)
+
+	req := callToolRequest(map[string]any{"sort_by": "messages", "limit": float64(2)})
+	result, err := handleStatsTop(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	text := extractResultText(t, result)
+	var list []archive.ListEntry
+	if err := json.Unmarshal([]byte(text), &list); err != nil {
+		t.Fatalf("expected JSON array, got: %s", text)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(list))
+	}
+	// Sorted by messages descending: run-3 (300) first
+	if list[0].Messages != 300 {
+		t.Errorf("first entry messages = %d, want 300", list[0].Messages)
+	}
+}
+
+func TestHandleStatsTopInvalidSortBy(t *testing.T) {
+	sc := testServerContext(t)
+
+	req := callToolRequest(map[string]any{"sort_by": "invalid"})
+	result, err := handleStatsTop(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertIsError(t, result)
 }

--- a/internal/tools/instance/tools.go
+++ b/internal/tools/instance/tools.go
@@ -46,6 +46,8 @@ func RegisterTools(s *mcpserver.MCPServer, sc *server.ServerContext) {
 	registerStatsSummary(s, sc)
 	registerStatsSpend(s, sc)
 	registerStatsTrends(s, sc)
+	registerStatsList(s, sc)
+	registerStatsTop(s, sc)
 }
 
 func registerCreate(s *mcpserver.MCPServer, sc *server.ServerContext) {

--- a/pkg/archive/stats.go
+++ b/pkg/archive/stats.go
@@ -9,9 +9,18 @@ import (
 
 // SummaryFilters controls which entries are included in the summary.
 type SummaryFilters struct {
-	Since   time.Time // zero means no lower bound
-	Repo    string    // empty means all repos
-	Outcome string    // empty means all outcomes
+	Since      time.Time // zero means no lower bound
+	Repo       string    // empty means all repos
+	Outcome    string    // empty means all outcomes
+	Complexity string    // empty means all complexities
+}
+
+// ComplexityGroup holds per-complexity-level stats for the summary breakdown.
+type ComplexityGroup struct {
+	Level      string  `json:"level"`
+	Runs       int     `json:"runs"`
+	AvgCost    float64 `json:"avg_cost"`
+	SuccessPct float64 `json:"success_pct"`
 }
 
 // SummaryStats is the aggregated overview of archived runs.
@@ -27,23 +36,59 @@ type SummaryStats struct {
 	AvgCostUSD     float64 `json:"avg_cost_usd"`
 	AvgMessages    int     `json:"avg_messages"`
 	MedianDuration string  `json:"median_duration"`
+
+	// Enriched fields
+	FirstAttempt       int     `json:"first_attempt"`
+	FirstAttemptPct    float64 `json:"first_attempt_pct"`
+	ScopeAdherence     int     `json:"scope_adherence"`
+	ScopeAdherencePct  float64 `json:"scope_adherence_pct"`
+	ScopeTotal         int     `json:"scope_total"`
+	ReworkNone         int     `json:"rework_none"`
+	ReworkMinor        int     `json:"rework_minor"`
+	ReworkMajor        int     `json:"rework_major"`
+	MinCost            float64 `json:"min_cost"`
+	MaxCost            float64 `json:"max_cost"`
+	MinMessages        int     `json:"min_messages"`
+	MaxMessages        int     `json:"max_messages"`
+	MinDuration        string  `json:"min_duration"`
+	MaxDuration        string  `json:"max_duration"`
+	ComplexityBreakdown []ComplexityGroup `json:"complexity_breakdown,omitempty"`
 }
 
 // SpendGroup is a single row in a cost breakdown.
 type SpendGroup struct {
 	Group      string  `json:"group"`
 	Runs       int     `json:"runs"`
+	PctOfTotal float64 `json:"pct_of_total"`
 	TotalCost  float64 `json:"total_cost"`
 	AvgCost    float64 `json:"avg_cost"`
 }
 
 // TrendWeek is a single row in the week-over-week trends table.
 type TrendWeek struct {
-	Week        string  `json:"week"`
-	Runs        int     `json:"runs"`
-	SuccessPct  float64 `json:"success_pct"`
-	AvgCostUSD  float64 `json:"avg_cost_usd"`
-	AvgMessages int     `json:"avg_messages"`
+	Week            string  `json:"week"`
+	Runs            int     `json:"runs"`
+	SuccessPct      float64 `json:"success_pct"`
+	FirstAttemptPct float64 `json:"first_attempt_pct"`
+	AvgCostUSD      float64 `json:"avg_cost_usd"`
+	TotalCostUSD    float64 `json:"total_cost_usd"`
+	AvgMessages     int     `json:"avg_messages"`
+	AvgDuration     string  `json:"avg_duration"`
+	AvgComplexity   float64 `json:"avg_complexity"`
+}
+
+// ListEntry holds the display fields for a single archive entry.
+type ListEntry struct {
+	Date       string        `json:"date"`
+	Name       string        `json:"name"`
+	Repo       string        `json:"repo"`
+	Issue      string        `json:"issue"`
+	Outcome    string        `json:"outcome"`
+	Cost       float64       `json:"cost"`
+	Messages   int           `json:"messages"`
+	Duration   string        `json:"duration"`
+	Complexity string        `json:"complexity"`
+	duration   time.Duration // unexported, used for sorting
 }
 
 // ComputeSummary aggregates stats from the given entries after applying filters.
@@ -59,6 +104,16 @@ func ComputeSummary(entries []*Entry, filters SummaryFilters) *SummaryStats {
 	var totalCost float64
 	var totalMessages int
 	var durations []time.Duration
+	hasCost := false
+	minMsgs, maxMsgs := math.MaxInt, 0
+
+	// Complexity accumulators
+	type complexityAcc struct {
+		runs    int
+		cost    float64
+		success int
+	}
+	complexityMap := make(map[string]*complexityAcc)
 
 	for _, e := range filtered {
 		outcome := e.Tags["outcome"]
@@ -71,13 +126,71 @@ func ComputeSummary(entries []*Entry, filters SummaryFilters) *SummaryStats {
 			s.Failure++
 		}
 
+		// First attempt
+		if e.Tags["first_attempt"] == "true" {
+			s.FirstAttempt++
+		}
+
+		// Scope adherence (only count entries that have the scope tag)
+		if scope := e.Tags["scope"]; scope != "" {
+			s.ScopeTotal++
+			if scope == "adhered" {
+				s.ScopeAdherence++
+			}
+		}
+
+		// Rework distribution
+		switch e.Tags["rework"] {
+		case "none":
+			s.ReworkNone++
+		case "minor":
+			s.ReworkMinor++
+		case "major":
+			s.ReworkMajor++
+		}
+
 		if e.TotalCostUSD != nil {
-			totalCost += *e.TotalCostUSD
+			c := *e.TotalCostUSD
+			totalCost += c
+			if !hasCost {
+				s.MinCost = c
+				s.MaxCost = c
+				hasCost = true
+			} else {
+				if c < s.MinCost {
+					s.MinCost = c
+				}
+				if c > s.MaxCost {
+					s.MaxCost = c
+				}
+			}
 		}
 		totalMessages += e.MessageCount
+		if e.MessageCount < minMsgs {
+			minMsgs = e.MessageCount
+		}
+		if e.MessageCount > maxMsgs {
+			maxMsgs = e.MessageCount
+		}
 
 		if !e.StartedAt.IsZero() && !e.StoppedAt.IsZero() {
 			durations = append(durations, e.StoppedAt.Sub(e.StartedAt))
+		}
+
+		// Complexity breakdown
+		if cplx := e.Tags["complexity"]; cplx != "" {
+			acc, ok := complexityMap[cplx]
+			if !ok {
+				acc = &complexityAcc{}
+				complexityMap[cplx] = acc
+			}
+			acc.runs++
+			if e.TotalCostUSD != nil {
+				acc.cost += *e.TotalCostUSD
+			}
+			if outcome == "success" {
+				acc.success++
+			}
 		}
 	}
 
@@ -85,10 +198,16 @@ func ComputeSummary(entries []*Entry, filters SummaryFilters) *SummaryStats {
 	s.TotalCostUSD = totalCost
 	s.AvgCostUSD = totalCost / n
 	s.AvgMessages = int(math.Round(float64(totalMessages) / n))
+	s.MinMessages = minMsgs
+	s.MaxMessages = maxMsgs
 
 	s.SuccessPct = pct(s.Success, s.TotalRuns)
 	s.PartialPct = pct(s.Partial, s.TotalRuns)
 	s.FailurePct = pct(s.Failure, s.TotalRuns)
+	s.FirstAttemptPct = pct(s.FirstAttempt, s.TotalRuns)
+	if s.ScopeTotal > 0 {
+		s.ScopeAdherencePct = pct(s.ScopeAdherence, s.ScopeTotal)
+	}
 
 	if len(durations) > 0 {
 		sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
@@ -100,6 +219,28 @@ func ComputeSummary(entries []*Entry, filters SummaryFilters) *SummaryStats {
 			median = durations[mid]
 		}
 		s.MedianDuration = formatStatsDuration(median)
+		s.MinDuration = formatStatsDuration(durations[0])
+		s.MaxDuration = formatStatsDuration(durations[len(durations)-1])
+	}
+
+	// Build complexity breakdown sorted by numeric level
+	if len(complexityMap) > 0 {
+		order := []string{"trivial", "simple", "moderate", "complex", "expert"}
+		for _, level := range order {
+			acc, ok := complexityMap[level]
+			if !ok {
+				continue
+			}
+			cg := ComplexityGroup{
+				Level:      level,
+				Runs:       acc.runs,
+				SuccessPct: pct(acc.success, acc.runs),
+			}
+			if acc.runs > 0 {
+				cg.AvgCost = acc.cost / float64(acc.runs)
+			}
+			s.ComplexityBreakdown = append(s.ComplexityBreakdown, cg)
+		}
 	}
 
 	return s
@@ -107,8 +248,14 @@ func ComputeSummary(entries []*Entry, filters SummaryFilters) *SummaryStats {
 
 // ComputeSpend groups entries by the given dimension and returns cost breakdowns.
 // groupBy is one of "week", "repo", or "complexity". weeks limits to the last N weeks.
-func ComputeSpend(entries []*Entry, groupBy string, weeks int) []SpendGroup {
+func ComputeSpend(entries []*Entry, groupBy string, weeks int, filters ...SummaryFilters) []SpendGroup {
 	cutoff := weekCutoff(weeks)
+
+	var f SummaryFilters
+	if len(filters) > 0 {
+		f = filters[0]
+	}
+
 	filtered := make([]*Entry, 0, len(entries))
 	for _, e := range entries {
 		if !e.StoppedAt.Before(cutoff) {
@@ -116,12 +263,16 @@ func ComputeSpend(entries []*Entry, groupBy string, weeks int) []SpendGroup {
 		}
 	}
 
+	// Apply additional filters
+	filtered = filterEntries(filtered, f)
+
 	type accumulator struct {
 		runs int
 		cost float64
 	}
 	groups := make(map[string]*accumulator)
 
+	var grandTotal float64
 	for _, e := range filtered {
 		var key string
 		switch groupBy {
@@ -147,16 +298,18 @@ func ComputeSpend(entries []*Entry, groupBy string, weeks int) []SpendGroup {
 		acc.runs++
 		if e.TotalCostUSD != nil {
 			acc.cost += *e.TotalCostUSD
+			grandTotal += *e.TotalCostUSD
 		}
 	}
 
 	result := make([]SpendGroup, 0, len(groups))
 	for k, acc := range groups {
 		result = append(result, SpendGroup{
-			Group:     k,
-			Runs:      acc.runs,
-			TotalCost: acc.cost,
-			AvgCost:   acc.cost / float64(acc.runs),
+			Group:      k,
+			Runs:       acc.runs,
+			PctOfTotal: pct64(acc.cost, grandTotal),
+			TotalCost:  acc.cost,
+			AvgCost:    acc.cost / float64(acc.runs),
 		})
 	}
 
@@ -168,19 +321,32 @@ func ComputeSpend(entries []*Entry, groupBy string, weeks int) []SpendGroup {
 }
 
 // ComputeTrends returns week-over-week trend data for the last N weeks.
-func ComputeTrends(entries []*Entry, weeks int) []TrendWeek {
+func ComputeTrends(entries []*Entry, weeks int, filters ...SummaryFilters) []TrendWeek {
 	cutoff := weekCutoff(weeks)
 
+	var f SummaryFilters
+	if len(filters) > 0 {
+		f = filters[0]
+	}
+
 	type accumulator struct {
-		runs     int
-		success  int
-		cost     float64
-		messages int
+		runs         int
+		success      int
+		firstAttempt int
+		cost         float64
+		messages     int
+		totalDur     time.Duration
+		durCount     int
+		complexSum   float64
+		complexCount int
 	}
 	weekMap := make(map[string]*accumulator)
 
 	for _, e := range entries {
 		if e.StoppedAt.Before(cutoff) {
+			continue
+		}
+		if !matchesFilters(e, f) {
 			continue
 		}
 		key := isoWeek(e.StoppedAt)
@@ -193,21 +359,43 @@ func ComputeTrends(entries []*Entry, weeks int) []TrendWeek {
 		if e.Tags["outcome"] == "success" {
 			acc.success++
 		}
+		if e.Tags["first_attempt"] == "true" {
+			acc.firstAttempt++
+		}
 		if e.TotalCostUSD != nil {
 			acc.cost += *e.TotalCostUSD
 		}
 		acc.messages += e.MessageCount
+
+		if !e.StartedAt.IsZero() && !e.StoppedAt.IsZero() {
+			acc.totalDur += e.StoppedAt.Sub(e.StartedAt)
+			acc.durCount++
+		}
+
+		if v := complexityToNumeric(e.Tags["complexity"]); v > 0 {
+			acc.complexSum += v
+			acc.complexCount++
+		}
 	}
 
 	result := make([]TrendWeek, 0, len(weekMap))
 	for k, acc := range weekMap {
-		result = append(result, TrendWeek{
-			Week:        k,
-			Runs:        acc.runs,
-			SuccessPct:  pct(acc.success, acc.runs),
-			AvgCostUSD:  acc.cost / float64(acc.runs),
-			AvgMessages: int(math.Round(float64(acc.messages) / float64(acc.runs))),
-		})
+		tw := TrendWeek{
+			Week:         k,
+			Runs:         acc.runs,
+			SuccessPct:   pct(acc.success, acc.runs),
+			FirstAttemptPct: pct(acc.firstAttempt, acc.runs),
+			AvgCostUSD:   acc.cost / float64(acc.runs),
+			TotalCostUSD: acc.cost,
+			AvgMessages:  int(math.Round(float64(acc.messages) / float64(acc.runs))),
+		}
+		if acc.durCount > 0 {
+			tw.AvgDuration = formatStatsDuration(acc.totalDur / time.Duration(acc.durCount))
+		}
+		if acc.complexCount > 0 {
+			tw.AvgComplexity = math.Round(acc.complexSum/float64(acc.complexCount)*10) / 10
+		}
+		result = append(result, tw)
 	}
 
 	sort.Slice(result, func(i, j int) bool {
@@ -217,23 +405,79 @@ func ComputeTrends(entries []*Entry, weeks int) []TrendWeek {
 	return result
 }
 
+// ComputeList returns a flat list of entries with display fields, filtered and sorted.
+func ComputeList(entries []*Entry, filters SummaryFilters, sortBy string, limit int) []ListEntry {
+	filtered := filterEntries(entries, filters)
+
+	result := make([]ListEntry, 0, len(filtered))
+	for _, e := range filtered {
+		var cost float64
+		if e.TotalCostUSD != nil {
+			cost = *e.TotalCostUSD
+		}
+		var dur string
+		var rawDur time.Duration
+		if !e.StartedAt.IsZero() && !e.StoppedAt.IsZero() {
+			rawDur = e.StoppedAt.Sub(e.StartedAt)
+			dur = formatStatsDuration(rawDur)
+		}
+		result = append(result, ListEntry{
+			Date:       e.StoppedAt.Format("2006-01-02"),
+			Name:       e.Name,
+			Repo:       e.Tags["repo"],
+			Issue:      e.Tags["issue"],
+			Outcome:    e.Tags["outcome"],
+			Cost:       cost,
+			Messages:   e.MessageCount,
+			Duration:   dur,
+			Complexity: e.Tags["complexity"],
+			duration:   rawDur,
+		})
+	}
+
+	switch sortBy {
+	case "cost":
+		sort.Slice(result, func(i, j int) bool { return result[i].Cost > result[j].Cost })
+	case "messages":
+		sort.Slice(result, func(i, j int) bool { return result[i].Messages > result[j].Messages })
+	case "duration":
+		sort.Slice(result, func(i, j int) bool { return result[i].duration > result[j].duration })
+	default: // "date"
+		sort.Slice(result, func(i, j int) bool { return result[i].Date > result[j].Date })
+	}
+
+	if limit > 0 && limit < len(result) {
+		result = result[:limit]
+	}
+	return result
+}
+
 // --- helpers ---
 
 func filterEntries(entries []*Entry, f SummaryFilters) []*Entry {
 	result := make([]*Entry, 0, len(entries))
 	for _, e := range entries {
-		if !f.Since.IsZero() && e.StoppedAt.Before(f.Since) {
-			continue
+		if matchesFilters(e, f) {
+			result = append(result, e)
 		}
-		if f.Repo != "" && e.Tags["repo"] != f.Repo {
-			continue
-		}
-		if f.Outcome != "" && e.Tags["outcome"] != f.Outcome {
-			continue
-		}
-		result = append(result, e)
 	}
 	return result
+}
+
+func matchesFilters(e *Entry, f SummaryFilters) bool {
+	if !f.Since.IsZero() && e.StoppedAt.Before(f.Since) {
+		return false
+	}
+	if f.Repo != "" && e.Tags["repo"] != f.Repo {
+		return false
+	}
+	if f.Outcome != "" && e.Tags["outcome"] != f.Outcome {
+		return false
+	}
+	if f.Complexity != "" && e.Tags["complexity"] != f.Complexity {
+		return false
+	}
+	return true
 }
 
 func pct(count, total int) float64 {
@@ -241,6 +485,13 @@ func pct(count, total int) float64 {
 		return 0
 	}
 	return math.Round(float64(count)/float64(total)*1000) / 10
+}
+
+func pct64(value, total float64) float64 {
+	if total == 0 {
+		return 0
+	}
+	return math.Round(value/total*1000) / 10
 }
 
 func isoWeek(t time.Time) string {
@@ -271,4 +522,23 @@ func formatStatsDuration(d time.Duration) string {
 		return fmt.Sprintf("%dh", hours)
 	}
 	return fmt.Sprintf("%dh%dm", hours, mins)
+}
+
+// complexityToNumeric maps complexity tag values to numeric scores.
+// Returns 0 for unknown/empty values.
+func complexityToNumeric(level string) float64 {
+	switch level {
+	case "trivial":
+		return 1
+	case "simple":
+		return 2
+	case "moderate":
+		return 3
+	case "complex":
+		return 4
+	case "expert":
+		return 5
+	default:
+		return 0
+	}
 }

--- a/pkg/archive/stats_test.go
+++ b/pkg/archive/stats_test.go
@@ -17,7 +17,14 @@ func makeEntries() []*Entry {
 			StoppedAt:    now.Add(-20 * time.Minute),
 			MessageCount: 100,
 			TotalCostUSD: f64(1.50),
-			Tags:         map[string]string{"outcome": "success", "repo": "frontend", "complexity": "simple"},
+			Tags: map[string]string{
+				"outcome":       "success",
+				"repo":          "frontend",
+				"complexity":    "simple",
+				"first_attempt": "true",
+				"scope":         "adhered",
+				"rework":        "none",
+			},
 		},
 		{
 			UUID:         "2",
@@ -26,7 +33,15 @@ func makeEntries() []*Entry {
 			StoppedAt:    now.Add(-50 * time.Minute),
 			MessageCount: 200,
 			TotalCostUSD: f64(3.00),
-			Tags:         map[string]string{"outcome": "partial", "repo": "backend", "complexity": "complex"},
+			Tags: map[string]string{
+				"outcome":       "partial",
+				"repo":          "backend",
+				"complexity":    "complex",
+				"first_attempt": "false",
+				"scope":         "adhered",
+				"rework":        "minor",
+				"issue":         "backend#42",
+			},
 		},
 		{
 			UUID:         "3",
@@ -35,7 +50,13 @@ func makeEntries() []*Entry {
 			StoppedAt:    now.Add(-80 * time.Minute),
 			MessageCount: 150,
 			TotalCostUSD: f64(2.00),
-			Tags:         map[string]string{"outcome": "failed", "repo": "frontend", "complexity": "simple"},
+			Tags: map[string]string{
+				"outcome":       "failed",
+				"repo":          "frontend",
+				"complexity":    "simple",
+				"first_attempt": "true",
+				"rework":        "major",
+			},
 		},
 		{
 			UUID:         "4",
@@ -44,7 +65,13 @@ func makeEntries() []*Entry {
 			StoppedAt:    now.Add(-110 * time.Minute),
 			MessageCount: 50,
 			TotalCostUSD: nil,
-			Tags:         map[string]string{"outcome": "success", "repo": "backend"},
+			Tags: map[string]string{
+				"outcome":       "success",
+				"repo":          "backend",
+				"first_attempt": "true",
+				"scope":         "deviated",
+				"rework":        "none",
+			},
 		},
 	}
 }
@@ -82,6 +109,98 @@ func TestComputeSummary_All(t *testing.T) {
 	}
 }
 
+func TestComputeSummary_EnrichedFields(t *testing.T) {
+	entries := makeEntries()
+	s := ComputeSummary(entries, SummaryFilters{})
+
+	// First attempt: entries 1, 3, 4 have first_attempt=true
+	if s.FirstAttempt != 3 {
+		t.Errorf("FirstAttempt = %d, want 3", s.FirstAttempt)
+	}
+	if s.FirstAttemptPct != 75 {
+		t.Errorf("FirstAttemptPct = %g, want 75", s.FirstAttemptPct)
+	}
+
+	// Scope: entries 1 (adhered), 2 (adhered), 4 (deviated) have scope tag
+	if s.ScopeTotal != 3 {
+		t.Errorf("ScopeTotal = %d, want 3", s.ScopeTotal)
+	}
+	if s.ScopeAdherence != 2 {
+		t.Errorf("ScopeAdherence = %d, want 2", s.ScopeAdherence)
+	}
+	if s.ScopeAdherencePct != 66.7 {
+		t.Errorf("ScopeAdherencePct = %g, want 66.7", s.ScopeAdherencePct)
+	}
+
+	// Rework: none=2, minor=1, major=1
+	if s.ReworkNone != 2 {
+		t.Errorf("ReworkNone = %d, want 2", s.ReworkNone)
+	}
+	if s.ReworkMinor != 1 {
+		t.Errorf("ReworkMinor = %d, want 1", s.ReworkMinor)
+	}
+	if s.ReworkMajor != 1 {
+		t.Errorf("ReworkMajor = %d, want 1", s.ReworkMajor)
+	}
+
+	// Cost range: 1.50, 3.00, 2.00 (entry 4 is nil)
+	if s.MinCost != 1.50 {
+		t.Errorf("MinCost = %f, want 1.50", s.MinCost)
+	}
+	if s.MaxCost != 3.00 {
+		t.Errorf("MaxCost = %f, want 3.00", s.MaxCost)
+	}
+
+	// Message range
+	if s.MinMessages != 50 {
+		t.Errorf("MinMessages = %d, want 50", s.MinMessages)
+	}
+	if s.MaxMessages != 200 {
+		t.Errorf("MaxMessages = %d, want 200", s.MaxMessages)
+	}
+
+	// Duration range: all entries are 10 min
+	if s.MinDuration != "10m" {
+		t.Errorf("MinDuration = %q, want %q", s.MinDuration, "10m")
+	}
+	if s.MaxDuration != "10m" {
+		t.Errorf("MaxDuration = %q, want %q", s.MaxDuration, "10m")
+	}
+}
+
+func TestComputeSummary_ComplexityBreakdown(t *testing.T) {
+	entries := makeEntries()
+	s := ComputeSummary(entries, SummaryFilters{})
+
+	// Entries 1,3 are simple; entry 2 is complex; entry 4 has no complexity tag
+	if len(s.ComplexityBreakdown) != 2 {
+		t.Fatalf("ComplexityBreakdown length = %d, want 2", len(s.ComplexityBreakdown))
+	}
+
+	// Order should be: simple, complex (ordered by level)
+	if s.ComplexityBreakdown[0].Level != "simple" {
+		t.Errorf("first breakdown level = %q, want %q", s.ComplexityBreakdown[0].Level, "simple")
+	}
+	if s.ComplexityBreakdown[0].Runs != 2 {
+		t.Errorf("simple runs = %d, want 2", s.ComplexityBreakdown[0].Runs)
+	}
+	// simple avg cost: (1.50+2.00)/2 = 1.75
+	if s.ComplexityBreakdown[0].AvgCost != 1.75 {
+		t.Errorf("simple avg cost = %f, want 1.75", s.ComplexityBreakdown[0].AvgCost)
+	}
+	// simple success: 1/2 = 50%
+	if s.ComplexityBreakdown[0].SuccessPct != 50 {
+		t.Errorf("simple success pct = %g, want 50", s.ComplexityBreakdown[0].SuccessPct)
+	}
+
+	if s.ComplexityBreakdown[1].Level != "complex" {
+		t.Errorf("second breakdown level = %q, want %q", s.ComplexityBreakdown[1].Level, "complex")
+	}
+	if s.ComplexityBreakdown[1].Runs != 1 {
+		t.Errorf("complex runs = %d, want 1", s.ComplexityBreakdown[1].Runs)
+	}
+}
+
 func TestComputeSummary_FilterByRepo(t *testing.T) {
 	entries := makeEntries()
 	s := ComputeSummary(entries, SummaryFilters{Repo: "frontend"})
@@ -100,6 +219,15 @@ func TestComputeSummary_FilterByRepo(t *testing.T) {
 func TestComputeSummary_FilterByOutcome(t *testing.T) {
 	entries := makeEntries()
 	s := ComputeSummary(entries, SummaryFilters{Outcome: "success"})
+
+	if s.TotalRuns != 2 {
+		t.Errorf("TotalRuns = %d, want 2", s.TotalRuns)
+	}
+}
+
+func TestComputeSummary_FilterByComplexity(t *testing.T) {
+	entries := makeEntries()
+	s := ComputeSummary(entries, SummaryFilters{Complexity: "simple"})
 
 	if s.TotalRuns != 2 {
 		t.Errorf("TotalRuns = %d, want 2", s.TotalRuns)
@@ -159,6 +287,23 @@ func TestComputeSpend_ByRepo(t *testing.T) {
 	}
 }
 
+func TestComputeSpend_PctOfTotal(t *testing.T) {
+	entries := makeEntries()
+	groups := ComputeSpend(entries, "repo", 0)
+
+	var totalPct float64
+	for _, g := range groups {
+		if g.PctOfTotal <= 0 {
+			t.Errorf("group %q PctOfTotal = %g, want > 0", g.Group, g.PctOfTotal)
+		}
+		totalPct += g.PctOfTotal
+	}
+	// Total should be ~100% (allow floating point)
+	if totalPct < 99 || totalPct > 101 {
+		t.Errorf("sum of PctOfTotal = %g, want ~100", totalPct)
+	}
+}
+
 func TestComputeSpend_ByComplexity(t *testing.T) {
 	entries := makeEntries()
 	groups := ComputeSpend(entries, "complexity", 0)
@@ -191,6 +336,21 @@ func TestComputeSpend_ByWeek(t *testing.T) {
 	}
 }
 
+func TestComputeSpend_WithFilters(t *testing.T) {
+	entries := makeEntries()
+	groups := ComputeSpend(entries, "repo", 0, SummaryFilters{Outcome: "success"})
+
+	// Only success entries: run-1 (frontend) and run-4 (backend)
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	for _, g := range groups {
+		if g.Runs != 1 {
+			t.Errorf("group %q runs = %d, want 1", g.Group, g.Runs)
+		}
+	}
+}
+
 func TestComputeTrends(t *testing.T) {
 	entries := makeEntries()
 	trends := ComputeTrends(entries, 0)
@@ -205,6 +365,49 @@ func TestComputeTrends(t *testing.T) {
 	}
 	if tw.SuccessPct != 50 {
 		t.Errorf("success pct = %g, want 50", tw.SuccessPct)
+	}
+}
+
+func TestComputeTrends_EnrichedFields(t *testing.T) {
+	entries := makeEntries()
+	trends := ComputeTrends(entries, 0)
+
+	if len(trends) != 1 {
+		t.Fatalf("expected 1 trend week, got %d", len(trends))
+	}
+	tw := trends[0]
+
+	// First attempt: 3/4 = 75%
+	if tw.FirstAttemptPct != 75 {
+		t.Errorf("FirstAttemptPct = %g, want 75", tw.FirstAttemptPct)
+	}
+
+	// Total cost: 6.50
+	if tw.TotalCostUSD != 6.50 {
+		t.Errorf("TotalCostUSD = %f, want 6.50", tw.TotalCostUSD)
+	}
+
+	// Avg duration: all 10m
+	if tw.AvgDuration != "10m" {
+		t.Errorf("AvgDuration = %q, want %q", tw.AvgDuration, "10m")
+	}
+
+	// Avg complexity: entries 1,3 are simple(2), entry 2 is complex(4), entry 4 has none
+	// (2+2+4)/3 = 2.666... -> 2.7
+	if tw.AvgComplexity != 2.7 {
+		t.Errorf("AvgComplexity = %g, want 2.7", tw.AvgComplexity)
+	}
+}
+
+func TestComputeTrends_WithFilters(t *testing.T) {
+	entries := makeEntries()
+	trends := ComputeTrends(entries, 0, SummaryFilters{Repo: "frontend"})
+
+	if len(trends) != 1 {
+		t.Fatalf("expected 1 trend week, got %d", len(trends))
+	}
+	if trends[0].Runs != 2 {
+		t.Errorf("runs = %d, want 2", trends[0].Runs)
 	}
 }
 
@@ -237,6 +440,147 @@ func TestComputeTrends_WeeksFilter(t *testing.T) {
 	}
 }
 
+func TestComputeList_Basic(t *testing.T) {
+	entries := makeEntries()
+	list := ComputeList(entries, SummaryFilters{}, "date", 0)
+
+	if len(list) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(list))
+	}
+	// Default sort by date descending: most recent first (run-1 stopped 20m ago)
+	if list[0].Name != "run-1" {
+		t.Errorf("first entry = %q, want run-1", list[0].Name)
+	}
+}
+
+func TestComputeList_SortByCost(t *testing.T) {
+	entries := makeEntries()
+	list := ComputeList(entries, SummaryFilters{}, "cost", 0)
+
+	if len(list) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(list))
+	}
+	// Most expensive first: run-2 ($3.00)
+	if list[0].Name != "run-2" {
+		t.Errorf("first entry = %q, want run-2", list[0].Name)
+	}
+}
+
+func TestComputeList_SortByMessages(t *testing.T) {
+	entries := makeEntries()
+	list := ComputeList(entries, SummaryFilters{}, "messages", 0)
+
+	// Most messages first: run-2 (200)
+	if list[0].Name != "run-2" {
+		t.Errorf("first entry = %q, want run-2", list[0].Name)
+	}
+}
+
+func TestComputeList_SortByDuration(t *testing.T) {
+	now := time.Now()
+	entries := []*Entry{
+		{
+			UUID: "short", Name: "short-run",
+			StartedAt: now.Add(-10 * time.Minute), StoppedAt: now.Add(-5 * time.Minute),
+			Tags: map[string]string{},
+		},
+		{
+			UUID: "long", Name: "long-run",
+			StartedAt: now.Add(-60 * time.Minute), StoppedAt: now.Add(-30 * time.Minute),
+			Tags: map[string]string{},
+		},
+	}
+	list := ComputeList(entries, SummaryFilters{}, "duration", 0)
+
+	if list[0].Name != "long-run" {
+		t.Errorf("first entry = %q, want long-run", list[0].Name)
+	}
+}
+
+func TestComputeList_WithFilters(t *testing.T) {
+	entries := makeEntries()
+	list := ComputeList(entries, SummaryFilters{Repo: "frontend"}, "date", 0)
+
+	if len(list) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(list))
+	}
+}
+
+func TestComputeList_WithLimit(t *testing.T) {
+	entries := makeEntries()
+	list := ComputeList(entries, SummaryFilters{}, "date", 2)
+
+	if len(list) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(list))
+	}
+}
+
+func TestComputeList_WithComplexityFilter(t *testing.T) {
+	entries := makeEntries()
+	list := ComputeList(entries, SummaryFilters{Complexity: "complex"}, "date", 0)
+
+	if len(list) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(list))
+	}
+	if list[0].Name != "run-2" {
+		t.Errorf("entry = %q, want run-2", list[0].Name)
+	}
+}
+
+func TestComputeList_Fields(t *testing.T) {
+	entries := makeEntries()
+	list := ComputeList(entries, SummaryFilters{Outcome: "partial"}, "date", 0)
+
+	if len(list) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(list))
+	}
+	le := list[0]
+	if le.Name != "run-2" {
+		t.Errorf("Name = %q, want run-2", le.Name)
+	}
+	if le.Repo != "backend" {
+		t.Errorf("Repo = %q, want backend", le.Repo)
+	}
+	if le.Issue != "backend#42" {
+		t.Errorf("Issue = %q, want backend#42", le.Issue)
+	}
+	if le.Outcome != "partial" {
+		t.Errorf("Outcome = %q, want partial", le.Outcome)
+	}
+	if le.Cost != 3.00 {
+		t.Errorf("Cost = %f, want 3.00", le.Cost)
+	}
+	if le.Messages != 200 {
+		t.Errorf("Messages = %d, want 200", le.Messages)
+	}
+	if le.Duration != "10m" {
+		t.Errorf("Duration = %q, want 10m", le.Duration)
+	}
+	if le.Complexity != "complex" {
+		t.Errorf("Complexity = %q, want complex", le.Complexity)
+	}
+}
+
+func TestComplexityToNumeric(t *testing.T) {
+	tests := []struct {
+		level string
+		want  float64
+	}{
+		{"trivial", 1},
+		{"simple", 2},
+		{"moderate", 3},
+		{"complex", 4},
+		{"expert", 5},
+		{"", 0},
+		{"unknown", 0},
+	}
+	for _, tt := range tests {
+		if got := complexityToNumeric(tt.level); got != tt.want {
+			t.Errorf("complexityToNumeric(%q) = %g, want %g", tt.level, got, tt.want)
+		}
+	}
+}
+
 func TestPct(t *testing.T) {
 	if got := pct(1, 3); got != 33.3 {
 		t.Errorf("pct(1,3) = %g, want 33.3", got)
@@ -246,6 +590,15 @@ func TestPct(t *testing.T) {
 	}
 	if got := pct(3, 3); got != 100 {
 		t.Errorf("pct(3,3) = %g, want 100", got)
+	}
+}
+
+func TestPct64(t *testing.T) {
+	if got := pct64(3.0, 6.0); got != 50 {
+		t.Errorf("pct64(3,6) = %g, want 50", got)
+	}
+	if got := pct64(0, 0); got != 0 {
+		t.Errorf("pct64(0,0) = %g, want 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- feat: extend stats command with richer summaries, list/top subcommands, filters, and complexity insights

## Related issues

Relates to #132

## Commits

### feat: extend stats command with richer summaries, list/top subcommands, filters, and complexity insights

Enrich stats summary with first-attempt rate, scope adherence, rework
distribution, cost/message/duration ranges, and per-complexity breakdown.

Add stats list subcommand for tabular view of individual archive entries
with --repo, --outcome, --complexity filters and --sort/--limit options.

Add stats top subcommand for outlier identification sorted by cost,
messages, or duration.

Add --repo, --outcome, --complexity filters to stats spend and stats
trends. Enrich trends with total cost, first-attempt %, avg duration,
and avg complexity score. Add %total column to spend output and support
--by complexity grouping.

Every new CLI flag/subcommand has an MCP tool equivalent with matching
params (klaus_stats_list, klaus_stats_top, plus new filter params on
existing spend/trends tools).

All new computation functions and MCP handlers have tests.

Closes #132

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

