### PR TITLE
feat: add klausctl messages command and klaus_messages MCP tool

### DIFF
--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -1,0 +1,211 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/instance"
+	"github.com/giantswarm/klausctl/pkg/mcpclient"
+	"github.com/giantswarm/klausctl/pkg/runtime"
+)
+
+var (
+	messagesFollow bool
+	messagesOutput string
+)
+
+var messagesCmd = &cobra.Command{
+	Use:   "messages [name]",
+	Short: "Display agent conversation messages",
+	Long: `Display all messages exchanged with the agent in a running instance.
+
+Each message shows the role (user, assistant, system, tool) and content.
+
+Examples:
+
+  klausctl messages dev
+  klausctl messages dev -f
+  klausctl messages dev -o json`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runMessages,
+}
+
+func init() {
+	messagesCmd.Flags().BoolVarP(&messagesFollow, "follow", "f", false, "follow new messages in real time")
+	messagesCmd.Flags().StringVarP(&messagesOutput, "output", "o", "text", "output format: text, json")
+	rootCmd.AddCommand(messagesCmd)
+}
+
+// agentMessage represents a single message in the agent conversation.
+type agentMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// agentMessagesResponse represents the JSON payload returned by the agent's
+// messages MCP tool.
+type agentMessagesResponse struct {
+	Status   string         `json:"status"`
+	Messages []agentMessage `json:"messages"`
+}
+
+// messagesCLIResult is the structured output for JSON mode.
+type messagesCLIResult struct {
+	Instance string         `json:"instance"`
+	Status   string         `json:"status"`
+	Count    int            `json:"count"`
+	Messages []agentMessage `json:"messages"`
+}
+
+func runMessages(cmd *cobra.Command, args []string) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	out := cmd.OutOrStdout()
+
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+	if err := config.MigrateLayout(paths); err != nil {
+		return fmt.Errorf("migrating config layout: %w", err)
+	}
+
+	instanceName, err := resolveOptionalInstanceName(args, "messages", cmd.ErrOrStderr())
+	if err != nil {
+		return err
+	}
+	paths = paths.ForInstance(instanceName)
+
+	inst, err := instance.Load(paths)
+	if err != nil {
+		return fmt.Errorf("no klaus instance found for %q; run 'klausctl create %s <workspace>' first", instanceName, instanceName)
+	}
+
+	rt, err := runtime.New(inst.Runtime)
+	if err != nil {
+		return err
+	}
+
+	status, err := rt.Status(ctx, inst.ContainerName())
+	if err != nil {
+		return fmt.Errorf("instance %q: unable to determine status: %w", instanceName, err)
+	}
+	if status != "running" {
+		return fmt.Errorf("instance %q is not running (status: %s); run 'klausctl start %s' first", instanceName, status, instanceName)
+	}
+
+	baseURL := fmt.Sprintf("http://localhost:%d/mcp", inst.Port)
+
+	client := mcpclient.New(buildVersion)
+	defer client.Close()
+
+	if !messagesFollow {
+		return fetchAndRenderMessages(ctx, out, client, instanceName, baseURL)
+	}
+
+	return followMessages(ctx, out, client, instanceName, baseURL)
+}
+
+func fetchAndRenderMessages(ctx context.Context, out io.Writer, client *mcpclient.Client, instanceName, baseURL string) error {
+	toolResult, err := client.Messages(ctx, instanceName, baseURL)
+	if err != nil {
+		return fmt.Errorf("fetching messages from %q: %w", instanceName, err)
+	}
+
+	return renderMessages(out, instanceName, toolResult)
+}
+
+func followMessages(ctx context.Context, out io.Writer, client *mcpclient.Client, instanceName, baseURL string) error {
+	var seen int
+	poll := 2 * time.Second
+	const maxPoll = 10 * time.Second
+
+	for {
+		toolResult, err := client.Messages(ctx, instanceName, baseURL)
+		if err != nil {
+			return fmt.Errorf("fetching messages from %q: %w", instanceName, err)
+		}
+
+		parsed := parseMessagesResponse(toolResult)
+		if len(parsed.Messages) > seen {
+			newMsgs := parsed.Messages[seen:]
+			for _, msg := range newMsgs {
+				renderSingleMessage(out, msg)
+			}
+			seen = len(parsed.Messages)
+			poll = 2 * time.Second // Reset backoff on new messages.
+		}
+
+		if agentTerminalStatuses[parsed.Status] {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(poll):
+		}
+
+		if poll < maxPoll {
+			poll = min(poll*2, maxPoll)
+		}
+	}
+}
+
+func renderMessages(out io.Writer, instanceName string, toolResult *mcp.CallToolResult) error {
+	parsed := parseMessagesResponse(toolResult)
+
+	result := messagesCLIResult{
+		Instance: instanceName,
+		Status:   parsed.Status,
+		Count:    len(parsed.Messages),
+		Messages: parsed.Messages,
+	}
+
+	if messagesOutput == "json" {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	fmt.Fprintf(out, "Instance: %s\n", result.Instance)
+	fmt.Fprintf(out, "Status:   %s\n", colorStatus(result.Status))
+	fmt.Fprintf(out, "Messages: %d\n\n", result.Count)
+
+	for _, msg := range result.Messages {
+		renderSingleMessage(out, msg)
+	}
+
+	return nil
+}
+
+func renderSingleMessage(out io.Writer, msg agentMessage) {
+	fmt.Fprintf(out, "[%s]\n%s\n\n", msg.Role, msg.Content)
+}
+
+// parseMessagesResponse extracts the messages array from the agent's MCP tool
+// response. The agent returns a JSON payload inside MCP TextContent.
+func parseMessagesResponse(toolResult *mcp.CallToolResult) agentMessagesResponse {
+	if toolResult != nil && toolResult.IsError {
+		return agentMessagesResponse{Status: "error"}
+	}
+
+	text := extractMCPText(toolResult)
+
+	var parsed agentMessagesResponse
+	if err := json.Unmarshal([]byte(text), &parsed); err == nil && parsed.Status != "" {
+		return parsed
+	}
+
+	return agentMessagesResponse{Status: "unknown"}
+}

--- a/cmd/messages_test.go
+++ b/cmd/messages_test.go
@@ -1,0 +1,204 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestParseMessagesResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		result     *mcp.CallToolResult
+		wantStatus string
+		wantCount  int
+	}{
+		{
+			name: "completed with messages",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{
+						Type: "text",
+						Text: `{"status":"completed","messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"hi"}]}`,
+					},
+				},
+			},
+			wantStatus: "completed",
+			wantCount:  2,
+		},
+		{
+			name: "busy with messages",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{
+						Type: "text",
+						Text: `{"status":"busy","messages":[{"role":"user","content":"do something"}]}`,
+					},
+				},
+			},
+			wantStatus: "busy",
+			wantCount:  1,
+		},
+		{
+			name: "idle with no messages",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{
+						Type: "text",
+						Text: `{"status":"idle","messages":[]}`,
+					},
+				},
+			},
+			wantStatus: "idle",
+			wantCount:  0,
+		},
+		{
+			name: "error from IsError flag",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{Type: "text", Text: "something went wrong"},
+				},
+				IsError: true,
+			},
+			wantStatus: "error",
+			wantCount:  0,
+		},
+		{
+			name:       "nil result",
+			result:     nil,
+			wantStatus: "unknown",
+			wantCount:  0,
+		},
+		{
+			name: "non-JSON fallback",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{Type: "text", Text: "plain text"},
+				},
+			},
+			wantStatus: "unknown",
+			wantCount:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseMessagesResponse(tt.result)
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			if len(got.Messages) != tt.wantCount {
+				t.Errorf("Messages count = %d, want %d", len(got.Messages), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestRenderMessages_Text(t *testing.T) {
+	colorEnabled = false
+	t.Cleanup(func() { colorEnabled = detectColor() })
+
+	result := &mcp.CallToolResult{
+		Content: []mcp.Content{
+			mcp.TextContent{
+				Type: "text",
+				Text: `{"status":"completed","messages":[{"role":"user","content":"hello world"},{"role":"assistant","content":"hi there"}]}`,
+			},
+		},
+	}
+
+	messagesOutput = "text"
+	var buf bytes.Buffer
+	err := renderMessages(&buf, "dev", result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"Instance: dev",
+		"Status:   completed",
+		"Messages: 2",
+		"[user]",
+		"hello world",
+		"[assistant]",
+		"hi there",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, output)
+		}
+	}
+}
+
+func TestRenderMessages_JSON(t *testing.T) {
+	messagesOutput = "json"
+	t.Cleanup(func() { messagesOutput = "text" })
+
+	result := &mcp.CallToolResult{
+		Content: []mcp.Content{
+			mcp.TextContent{
+				Type: "text",
+				Text: `{"status":"completed","messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"}]}`,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := renderMessages(&buf, "dev", result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var decoded messagesCLIResult
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v\ngot:\n%s", err, buf.String())
+	}
+
+	if decoded.Instance != "dev" {
+		t.Errorf("Instance = %q, want %q", decoded.Instance, "dev")
+	}
+	if decoded.Status != "completed" {
+		t.Errorf("Status = %q, want %q", decoded.Status, "completed")
+	}
+	if decoded.Count != 2 {
+		t.Errorf("Count = %d, want %d", decoded.Count, 2)
+	}
+	if len(decoded.Messages) != 2 {
+		t.Fatalf("Messages length = %d, want %d", len(decoded.Messages), 2)
+	}
+	if decoded.Messages[0].Role != "user" {
+		t.Errorf("Messages[0].Role = %q, want %q", decoded.Messages[0].Role, "user")
+	}
+	if decoded.Messages[1].Content != "world" {
+		t.Errorf("Messages[1].Content = %q, want %q", decoded.Messages[1].Content, "world")
+	}
+}
+
+func TestRenderMessages_Empty(t *testing.T) {
+	colorEnabled = false
+	t.Cleanup(func() { colorEnabled = detectColor() })
+
+	result := &mcp.CallToolResult{
+		Content: []mcp.Content{
+			mcp.TextContent{
+				Type: "text",
+				Text: `{"status":"idle","messages":[]}`,
+			},
+		},
+	}
+
+	messagesOutput = "text"
+	var buf bytes.Buffer
+	err := renderMessages(&buf, "dev", result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Messages: 0") {
+		t.Errorf("expected 'Messages: 0' in output, got:\n%s", output)
+	}
+}

--- a/internal/tools/instance/agent.go
+++ b/internal/tools/instance/agent.go
@@ -11,6 +11,7 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
 	"github.com/giantswarm/klausctl/internal/server"
+	"github.com/giantswarm/klausctl/pkg/config"
 	"github.com/giantswarm/klausctl/pkg/instance"
 	"github.com/giantswarm/klausctl/pkg/runtime"
 )
@@ -153,6 +154,133 @@ func handleResult(ctx context.Context, req mcp.CallToolRequest, sc *server.Serve
 		Status:   "completed",
 		Result:   text,
 	})
+}
+
+func registerMessages(s *mcpserver.MCPServer, sc *server.ServerContext) {
+	tool := mcp.NewTool("klaus_messages",
+		mcp.WithDescription("Retrieve conversation messages from a running klaus instance"),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Instance name")),
+		mcp.WithBoolean("follow", mcp.Description("Poll for new messages until the agent completes (default: false)")),
+	)
+	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleMessages(ctx, req, sc)
+	})
+}
+
+type messagesResult struct {
+	Instance string           `json:"instance"`
+	Status   string           `json:"status"`
+	Count    int              `json:"count"`
+	Messages []agentMessageMC `json:"messages"`
+}
+
+type agentMessageMC struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type agentMessagesToolResponse struct {
+	Status   string           `json:"status"`
+	Messages []agentMessageMC `json:"messages"`
+}
+
+func handleMessages(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
+	name, err := req.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if err := config.ValidateInstanceName(name); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	follow := req.GetBool("follow", false)
+
+	baseURL, err := agentBaseURL(ctx, name, sc)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	if !follow {
+		return fetchMessages(ctx, name, baseURL, sc)
+	}
+
+	return followMessagesUntilDone(ctx, name, baseURL, sc)
+}
+
+func fetchMessages(ctx context.Context, name, baseURL string, sc *server.ServerContext) (*mcp.CallToolResult, error) {
+	toolResult, err := sc.MCPClient.Messages(ctx, name, baseURL)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("fetching messages from %q: %v", name, err)), nil
+	}
+
+	if toolResult.IsError {
+		return server.JSONResult(messagesResult{
+			Instance: name,
+			Status:   "error",
+			Messages: []agentMessageMC{},
+		})
+	}
+
+	text := extractText(toolResult)
+	var parsed agentMessagesToolResponse
+	if err := json.Unmarshal([]byte(text), &parsed); err == nil && parsed.Status != "" {
+		return server.JSONResult(messagesResult{
+			Instance: name,
+			Status:   parsed.Status,
+			Count:    len(parsed.Messages),
+			Messages: parsed.Messages,
+		})
+	}
+
+	return server.JSONResult(messagesResult{
+		Instance: name,
+		Status:   "unknown",
+		Messages: []agentMessageMC{},
+	})
+}
+
+func followMessagesUntilDone(ctx context.Context, name, baseURL string, sc *server.ServerContext) (*mcp.CallToolResult, error) {
+	const maxFollowDuration = 30 * time.Minute
+	ctx, cancel := context.WithTimeout(ctx, maxFollowDuration)
+	defer cancel()
+
+	poll := 2 * time.Second
+	const maxPoll = 10 * time.Second
+
+	var lastResult *mcp.CallToolResult
+
+	for {
+		toolResult, err := sc.MCPClient.Messages(ctx, name, baseURL)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("fetching messages from %q: %v", name, err)), nil
+		}
+
+		text := extractText(toolResult)
+		var parsed agentMessagesToolResponse
+		if json.Unmarshal([]byte(text), &parsed) == nil {
+			lastResult, _ = server.JSONResult(messagesResult{
+				Instance: name,
+				Status:   parsed.Status,
+				Count:    len(parsed.Messages),
+				Messages: parsed.Messages,
+			})
+			if terminalStatuses[parsed.Status] {
+				return lastResult, nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			if lastResult != nil {
+				return lastResult, nil
+			}
+			return mcp.NewToolResultError("timed out waiting for messages"), nil
+		case <-time.After(poll):
+		}
+
+		if poll < maxPoll {
+			poll = min(poll*2, maxPoll)
+		}
+	}
 }
 
 // agentBaseURL resolves the MCP endpoint URL for a running instance.

--- a/internal/tools/instance/agent_test.go
+++ b/internal/tools/instance/agent_test.go
@@ -202,6 +202,36 @@ func TestParseAgentToolResponse(t *testing.T) {
 	}
 }
 
+func TestHandleMessagesMissingName(t *testing.T) {
+	sc := testServerContext(t)
+	req := callToolRequest(map[string]any{})
+	result, err := handleMessages(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertIsError(t, result)
+}
+
+func TestHandleMessagesInvalidName(t *testing.T) {
+	sc := testServerContext(t)
+	req := callToolRequest(map[string]any{"name": "../../etc"})
+	result, err := handleMessages(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertIsError(t, result)
+}
+
+func TestHandleMessagesInstanceNotFound(t *testing.T) {
+	sc := testServerContext(t)
+	req := callToolRequest(map[string]any{"name": "nonexistent"})
+	result, err := handleMessages(context.Background(), req, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertIsError(t, result)
+}
+
 func TestAgentBaseURLInstanceNotFound(t *testing.T) {
 	sc := testServerContext(t)
 	_, err := agentBaseURL(context.Background(), "nonexistent", sc)

--- a/internal/tools/instance/tools.go
+++ b/internal/tools/instance/tools.go
@@ -42,6 +42,7 @@ func RegisterTools(s *mcpserver.MCPServer, sc *server.ServerContext) {
 	registerPrompt(s, sc)
 	registerResult(s, sc)
 	registerRun(s, sc)
+	registerMessages(s, sc)
 	registerArchiveList(s, sc)
 	registerArchiveShow(s, sc)
 	registerArchiveTag(s, sc)

--- a/pkg/mcpclient/client.go
+++ b/pkg/mcpclient/client.go
@@ -123,6 +123,11 @@ func (c *Client) Result(ctx context.Context, instanceName, baseURL string, full 
 	return c.callTool(ctx, instanceName, baseURL, "result", args)
 }
 
+// Messages retrieves the agent's conversation messages.
+func (c *Client) Messages(ctx context.Context, instanceName, baseURL string) (*mcp.CallToolResult, error) {
+	return c.callTool(ctx, instanceName, baseURL, "messages", map[string]any{})
+}
+
 // SessionID returns the MCP session ID for the given instance, if any.
 func (c *Client) SessionID(instanceName string) string {
 	c.mu.Lock()


### PR DESCRIPTION
## Summary

- Adds `klausctl messages <instance>` CLI command to display all agent conversation messages (role + content)
- Adds `klausctl messages -f <instance>` follow mode that polls for new messages until the agent completes
- Adds `klaus_messages` MCP tool with `name` (required) and `follow` (optional) parameters for CLI/MCP parity
- Supports `--output text|json` formatting

## Approach

Follows the same patterns as `klausctl result` and `klausctl logs`:
- CLI command in `cmd/messages.go` using Cobra, with `--follow/-f` and `--output/-o` flags
- MCP tool registered in `internal/tools/instance/agent.go` alongside `klaus_prompt` and `klaus_result`
- MCP client method added to `pkg/mcpclient/client.go`
- Instance name validated via `config.ValidateInstanceName` in the MCP handler to prevent path traversal
- Follow mode includes a 30-minute timeout guard to prevent unbounded polling

The agent's `messages` tool (inside the container) is expected to return a JSON payload with `status` and `messages` fields, where each message has `role` and `content`.

## Issue reference

Closes giantswarm/giantswarm#36063

## Test plan

- [x] Unit tests for `parseMessagesResponse` covering all response shapes (completed, busy, idle, error, nil, non-JSON)
- [x] Unit tests for text and JSON rendering of messages output
- [x] Unit tests for MCP tool handler: missing name, invalid name (path traversal), instance not found
- [x] All existing tests pass (`go test ./...` -- 2 pre-existing failures in `pkg/orchestrator` unrelated to this change)
- [x] `go vet ./...` passes
- [x] Code reviewed by `base:code-reviewer` and `code-quality:security-auditor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)