### PR TITLE
feat: add pkg/gatewaybridge for klaus-gateway lifecycle (#195)

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -1,0 +1,220 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/klausctl/internal/gatewaysurface"
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/gatewaybridge"
+)
+
+var (
+	gatewayStartWithAgentGateway bool
+	gatewayStartPort             int
+	gatewayStartAgentPort        int
+	gatewayStartKlausGatewayBin  string
+	gatewayStartAgentGatewayBin  string
+	gatewayStartLogLevel         string
+
+	gatewayStatusOutput string
+)
+
+var gatewayCmd = &cobra.Command{
+	Use:   "gateway",
+	Short: "Manage the klaus-gateway bridge",
+	Long: `Manage the local klaus-gateway service (and optionally the upstream
+agentgateway it can run behind).
+
+The bridge owns the process lifecycle, tracks PID/port in ~/.config/klausctl/,
+health-checks /healthz, and registers klaus-gateway in mcpservers.yaml so
+containerized klaus instances can reach it via host.docker.internal.`,
+}
+
+var gatewayStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the klaus-gateway bridge",
+	Args:  cobra.NoArgs,
+	RunE:  runGatewayStart,
+}
+
+var gatewayStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the klaus-gateway bridge",
+	Args:  cobra.NoArgs,
+	RunE:  runGatewayStop,
+}
+
+var gatewayStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show klaus-gateway bridge status",
+	Args:  cobra.NoArgs,
+	RunE:  runGatewayStatus,
+}
+
+func init() {
+	// Every flag declared in gatewaysurface.StartFlags must have a matching
+	// binding below. The parity test enforces that both surfaces line up.
+	startFlags := gatewayStartCmd.Flags()
+	startFlags.BoolVar(&gatewayStartWithAgentGateway, startFlagName("with-agentgateway"), false, startFlagDesc("with-agentgateway"))
+	startFlags.IntVar(&gatewayStartPort, startFlagName("port"), 0, startFlagDesc("port"))
+	startFlags.IntVar(&gatewayStartAgentPort, startFlagName("agentgateway-port"), 0, startFlagDesc("agentgateway-port"))
+	startFlags.StringVar(&gatewayStartKlausGatewayBin, startFlagName("klaus-gateway-bin"), "", startFlagDesc("klaus-gateway-bin"))
+	startFlags.StringVar(&gatewayStartAgentGatewayBin, startFlagName("agentgateway-bin"), "", startFlagDesc("agentgateway-bin"))
+	startFlags.StringVar(&gatewayStartLogLevel, startFlagName("log-level"), "", startFlagDesc("log-level"))
+
+	gatewayStatusCmd.Flags().StringVarP(&gatewayStatusOutput, statusFlagName("output"), "o", "text", statusFlagDesc("output"))
+
+	gatewayCmd.AddCommand(gatewayStartCmd)
+	gatewayCmd.AddCommand(gatewayStopCmd)
+	gatewayCmd.AddCommand(gatewayStatusCmd)
+	rootCmd.AddCommand(gatewayCmd)
+}
+
+// startFlagName returns the canonical CLI flag name for a key declared in
+// gatewaysurface.StartFlags; panics on unknown key so misspellings fail at
+// init time.
+func startFlagName(key string) string {
+	for _, f := range gatewaysurface.StartFlags {
+		if f.CLIFlag == key {
+			return f.CLIFlag
+		}
+	}
+	panic("unknown gateway start flag: " + key)
+}
+
+func startFlagDesc(key string) string {
+	for _, f := range gatewaysurface.StartFlags {
+		if f.CLIFlag == key {
+			return f.Description
+		}
+	}
+	panic("unknown gateway start flag: " + key)
+}
+
+func statusFlagName(key string) string {
+	for _, f := range gatewaysurface.StatusFlags {
+		if f.CLIFlag == key {
+			return f.CLIFlag
+		}
+	}
+	panic("unknown gateway status flag: " + key)
+}
+
+func statusFlagDesc(key string) string {
+	for _, f := range gatewaysurface.StatusFlags {
+		if f.CLIFlag == key {
+			return f.Description
+		}
+	}
+	panic("unknown gateway status flag: " + key)
+}
+
+func runGatewayStart(cmd *cobra.Command, _ []string) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	out := cmd.OutOrStdout()
+
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, "Starting klaus-gateway bridge...")
+	st, err := gatewaybridge.Start(ctx, paths, gatewaybridge.Options{
+		WithAgentGateway: gatewayStartWithAgentGateway,
+		Port:             gatewayStartPort,
+		AgentGatewayPort: gatewayStartAgentPort,
+		KlausGatewayBin:  gatewayStartKlausGatewayBin,
+		AgentGatewayBin:  gatewayStartAgentGatewayBin,
+		LogLevel:         gatewayStartLogLevel,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, green("klaus-gateway bridge running."))
+	printGatewayStatus(out, st)
+	return nil
+}
+
+func runGatewayStop(cmd *cobra.Command, _ []string) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	out := cmd.OutOrStdout()
+
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+
+	if err := gatewaybridge.Stop(ctx, paths); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, green("klaus-gateway bridge stopped."))
+	return nil
+}
+
+func runGatewayStatus(cmd *cobra.Command, _ []string) error {
+	out := cmd.OutOrStdout()
+
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+
+	st := gatewaybridge.GetStatus(paths)
+
+	if strings.EqualFold(gatewayStatusOutput, "json") {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(st)
+	}
+
+	if !st.Running {
+		fmt.Fprintln(out, "klaus-gateway bridge: not running")
+		return nil
+	}
+	fmt.Fprintln(out, "klaus-gateway bridge:", green("running"))
+	printGatewayStatus(out, st)
+	return nil
+}
+
+func printGatewayStatus(out io.Writer, st *gatewaybridge.Status) {
+	fmt.Fprintf(out, "  PID:      %d\n", st.PID)
+	fmt.Fprintf(out, "  Port:     %d\n", st.Port)
+	fmt.Fprintf(out, "  URL:      %s\n", st.URL)
+	if st.Mode != "" {
+		fmt.Fprintf(out, "  Mode:     %s\n", st.Mode)
+	}
+	healthLabel := "yes"
+	if !st.Healthy {
+		healthLabel = yellow("no")
+	}
+	fmt.Fprintf(out, "  Healthy:  %s\n", healthLabel)
+	if len(st.Adapters) > 0 {
+		fmt.Fprintf(out, "  Adapters: %s\n", strings.Join(st.Adapters, ", "))
+	}
+	if st.WithAgentGateway && st.AgentGateway != nil {
+		fmt.Fprintln(out, "  agentgateway:")
+		fmt.Fprintf(out, "    PID:     %d\n", st.AgentGateway.PID)
+		fmt.Fprintf(out, "    Port:    %d\n", st.AgentGateway.Port)
+		fmt.Fprintf(out, "    URL:     %s\n", st.AgentGateway.URL)
+		aghealth := "yes"
+		if !st.AgentGateway.Healthy {
+			aghealth = yellow("no")
+		}
+		fmt.Fprintf(out, "    Healthy: %s\n", aghealth)
+	}
+}

--- a/cmd/gateway_parity_test.go
+++ b/cmd/gateway_parity_test.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/spf13/pflag"
+
+	"github.com/giantswarm/klausctl/internal/gatewaysurface"
+	internalserver "github.com/giantswarm/klausctl/internal/server"
+	gatewaytools "github.com/giantswarm/klausctl/internal/tools/gateway"
+	"github.com/giantswarm/klausctl/pkg/config"
+)
+
+// TestGatewayStartFlagParity asserts every flag declared on `gateway start`
+// has an MCP input equivalent on klaus_gateway_start, and vice versa -- the
+// acceptance criterion for this feature.
+func TestGatewayStartFlagParity(t *testing.T) {
+	cliFlags := collectCLIFlagNames(gatewayStartCmd.Flags())
+	surfaceCLI := cliFlagNames(gatewaysurface.StartFlags)
+
+	assertSetEqual(t, "CLI flags on `klausctl gateway start`", cliFlags, surfaceCLI)
+
+	mcpKeys := collectMCPToolProperties(t, "klaus_gateway_start")
+	surfaceMCP := mcpKeyNames(gatewaysurface.StartFlags)
+
+	assertSetEqual(t, "MCP inputs on klaus_gateway_start", mcpKeys, surfaceMCP)
+
+	// Every surface entry ties a CLI flag to an MCP key one-to-one.
+	if len(cliFlags) != len(mcpKeys) {
+		t.Errorf("CLI flag count (%d) differs from MCP input count (%d)", len(cliFlags), len(mcpKeys))
+	}
+}
+
+// TestGatewayStatusFlagParity asserts the same invariant for the status surface.
+func TestGatewayStatusFlagParity(t *testing.T) {
+	cliFlags := collectCLIFlagNames(gatewayStatusCmd.Flags())
+	surfaceCLI := cliFlagNames(gatewaysurface.StatusFlags)
+
+	assertSetEqual(t, "CLI flags on `klausctl gateway status`", cliFlags, surfaceCLI)
+
+	mcpKeys := collectMCPToolProperties(t, "klaus_gateway_status")
+	surfaceMCP := mcpKeyNames(gatewaysurface.StatusFlags)
+
+	assertSetEqual(t, "MCP inputs on klaus_gateway_status", mcpKeys, surfaceMCP)
+
+	if len(cliFlags) != len(mcpKeys) {
+		t.Errorf("CLI flag count (%d) differs from MCP input count (%d)", len(cliFlags), len(mcpKeys))
+	}
+}
+
+// TestGatewayMCPToolsRegistered sanity-checks that all three MCP tools are
+// exposed with the expected names.
+func TestGatewayMCPToolsRegistered(t *testing.T) {
+	srv := newToolsServer(t)
+	tools := srv.ListTools()
+
+	want := []string{"klaus_gateway_start", "klaus_gateway_stop", "klaus_gateway_status"}
+	for _, name := range want {
+		if _, ok := tools[name]; !ok {
+			t.Errorf("expected MCP tool %q to be registered; got %v", name, toolNames(tools))
+		}
+	}
+}
+
+func TestGatewayCommandRegistered(t *testing.T) {
+	assertCommandOnRoot(t, "gateway")
+}
+
+// collectCLIFlagNames returns the set of declared flag names on a pflag.FlagSet.
+func collectCLIFlagNames(fs *pflag.FlagSet) map[string]struct{} {
+	names := map[string]struct{}{}
+	fs.VisitAll(func(f *pflag.Flag) {
+		names[f.Name] = struct{}{}
+	})
+	return names
+}
+
+// collectMCPToolProperties returns the set of input property names registered
+// on the named MCP tool.
+func collectMCPToolProperties(t *testing.T, toolName string) map[string]struct{} {
+	t.Helper()
+	srv := newToolsServer(t)
+	tools := srv.ListTools()
+	tool, ok := tools[toolName]
+	if !ok {
+		t.Fatalf("MCP tool %q is not registered; available tools: %v", toolName, toolNames(tools))
+	}
+	props := map[string]struct{}{}
+	for k := range tool.Tool.InputSchema.Properties {
+		props[k] = struct{}{}
+	}
+	return props
+}
+
+// newToolsServer builds a fresh MCP server with klaus-gateway tools registered
+// against it. The backing ServerContext uses ephemeral paths so nothing on the
+// host filesystem is touched.
+func newToolsServer(t *testing.T) *server.MCPServer {
+	t.Helper()
+	srv := server.NewMCPServer("klausctl-test", "test")
+	sc := &internalserver.ServerContext{
+		Paths: &config.Paths{
+			ConfigDir: t.TempDir(),
+		},
+	}
+	gatewaytools.RegisterTools(srv, sc)
+	return srv
+}
+
+func cliFlagNames(flags []gatewaysurface.Flag) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, f := range flags {
+		out[f.CLIFlag] = struct{}{}
+	}
+	return out
+}
+
+func mcpKeyNames(flags []gatewaysurface.Flag) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, f := range flags {
+		out[f.MCPKey] = struct{}{}
+	}
+	return out
+}
+
+func assertSetEqual(t *testing.T, label string, got, want map[string]struct{}) {
+	t.Helper()
+	missing := difference(want, got)
+	extra := difference(got, want)
+	if len(missing) == 0 && len(extra) == 0 {
+		return
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("%s missing expected entries: %v", label, missing)
+	}
+	if len(extra) > 0 {
+		sort.Strings(extra)
+		t.Errorf("%s has unexpected entries: %v", label, extra)
+	}
+}
+
+func difference(a, b map[string]struct{}) []string {
+	var out []string
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+func toolNames(tools map[string]*server.ServerTool) []string {
+	names := make([]string, 0, len(tools))
+	for name := range tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/klausctl/internal/server"
 	artifacttools "github.com/giantswarm/klausctl/internal/tools/artifact"
 	cachetools "github.com/giantswarm/klausctl/internal/tools/cache"
+	gatewaytools "github.com/giantswarm/klausctl/internal/tools/gateway"
 	instancetools "github.com/giantswarm/klausctl/internal/tools/instance"
 	mustertools "github.com/giantswarm/klausctl/internal/tools/muster"
 	workspacetools "github.com/giantswarm/klausctl/internal/tools/workspace"
@@ -72,6 +73,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 	artifacttools.RegisterTools(mcpSrv, serverCtx)
 	cachetools.RegisterTools(mcpSrv, serverCtx)
 	mustertools.RegisterTools(mcpSrv, serverCtx)
+	gatewaytools.RegisterTools(mcpSrv, serverCtx)
 	workspacetools.RegisterTools(mcpSrv, serverCtx)
 
 	return mcpserver.ServeStdio(mcpSrv)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/gatewaybridge"
 	"github.com/giantswarm/klausctl/pkg/instance"
 	"github.com/giantswarm/klausctl/pkg/orchestrator"
 	"github.com/giantswarm/klausctl/pkg/renderer"
@@ -169,6 +170,22 @@ func startInstance(cmd *cobra.Command, instanceName, workspaceOverride, configPa
 	image := orchestrator.ResolveDefaultImage(ctx, client, cfg.Image, out)
 	cfg.Image = image
 
+	// Auto-start klaus-gateway before the instance when the resolved spec
+	// declares `requires.gateway: true`. This runs before ResolveSecretRefs
+	// so the registered klaus-gateway entry in mcpservers.yaml can flow
+	// through the usual mcpServerRefs -> mcpServers path.
+	if cfg.Requires.Gateway.Enabled {
+		fmt.Fprintln(out, "Ensuring klaus-gateway bridge is running...")
+		if _, err := gatewaybridge.EnsureRunning(ctx, paths, gatewaybridge.Options{
+			WithAgentGateway: cfg.Requires.Gateway.WithAgentGateway,
+		}); err != nil {
+			return fmt.Errorf("auto-starting klaus-gateway bridge: %w", err)
+		}
+		if !containsString(cfg.McpServerRefs, gatewaybridge.BridgeName) {
+			cfg.McpServerRefs = append(cfg.McpServerRefs, gatewaybridge.BridgeName)
+		}
+	}
+
 	// Resolve secret references (mcpServerRefs -> mcpServers) before rendering.
 	if err := orchestrator.ResolveSecretRefs(cfg, paths); err != nil {
 		return err
@@ -273,4 +290,13 @@ func applyWorkspaceOverride(cfg *config.Config, workspaceOverride string) {
 		cfg.Workspace = workspaceOverride
 		cfg.WorktreePath = "" // override disables worktree isolation
 	}
+}
+
+func containsString(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }

--- a/docs/gatewaybridge.md
+++ b/docs/gatewaybridge.md
@@ -1,0 +1,139 @@
+# Gateway bridge
+
+The gateway bridge is klausctl's local lifecycle manager for `klaus-gateway`
+(and optionally the upstream `agentgateway` that `klaus-gateway` can run
+behind). It mirrors the shape of [the muster bridge](musterbridge.md): it
+spawns the process, tracks PID/port, health-checks `/healthz`, and registers
+the resulting MCP HTTP endpoint in `~/.config/klausctl/mcpservers.yaml` so
+containerized klaus instances can reach it via `host.docker.internal`.
+
+## CLI
+
+```
+klausctl gateway start [--with-agentgateway] [--port N] \
+                       [--agentgateway-port N] \
+                       [--klaus-gateway-bin PATH] \
+                       [--agentgateway-bin PATH] \
+                       [--log-level LEVEL]
+klausctl gateway status [-o json]
+klausctl gateway stop
+```
+
+The CLI is the user-facing surface. Every flag is also accepted by the MCP
+tools below; a parity test (`cmd/gateway_parity_test.go`) fails the build if
+the two surfaces drift.
+
+## MCP tools
+
+Agents running inside `klausctl serve` see three tools:
+
+- `klaus_gateway_start` -- same arguments as `gateway start`, returns the
+  status JSON.
+- `klaus_gateway_stop` -- no arguments.
+- `klaus_gateway_status` -- returns the same JSON shape the CLI emits with
+  `-o json`.
+
+## Runtime selection
+
+The bridge looks up the gateway binary in this order:
+
+1. `--klaus-gateway-bin` / `--agentgateway-bin` flags on `gateway start`.
+2. `KLAUS_GATEWAY_BIN` / `KLAUS_AGENTGATEWAY_BIN` environment variables.
+3. `klaus-gateway` / `agentgateway` on `$PATH`.
+
+When none of these resolve, start fails with a clear error. Container-mode
+start via Docker/Podman is reserved for a future change: it will be wired to
+the existing runtime package, and the `--klaus-gateway-bin` escape hatch will
+still override it.
+
+## State directory layout
+
+```
+~/.config/klausctl/
+  mcpservers.yaml          # klausctl auto-registers klaus-gateway on start
+  gateway/                 # mixed ownership -- see below
+    config.yaml            # user-owned: adapters, agentgateway on/off, log level
+    routes.bolt            # klausctl-owned: passed to klaus-gateway as --bolt-path
+    slack-secrets.yaml     # user-owned (populated when the slack adapter ships)
+  klaus-gateway.pid        # klausctl-owned
+  klaus-gateway.port       # klausctl-owned
+  agentgateway.pid         # klausctl-owned (only when --with-agentgateway)
+  agentgateway.port        # klausctl-owned
+```
+
+### Ownership boundaries
+
+Strict ownership is part of the contract and is covered by the
+`TestOwnership` unit test in `pkg/gatewaybridge`.
+
+**klausctl owns**
+
+- `klaus-gateway.pid` / `klaus-gateway.port`
+- `agentgateway.pid` / `agentgateway.port`
+- `gateway/routes.bolt`
+
+**The user owns**
+
+- `gateway/config.yaml`
+- `gateway/slack-secrets.yaml`
+
+klausctl never writes to user-owned files; the user should never touch
+klausctl-owned files. `gateway stop` cleans up the klausctl-owned PID/port
+files and removes the `klaus-gateway` entry from `mcpservers.yaml` but
+leaves `gateway/config.yaml` and `gateway/slack-secrets.yaml` untouched.
+
+### `gateway/config.yaml` schema
+
+All fields are optional. klausctl reads only the keys below; the gateway
+binary itself reads the full file.
+
+```yaml
+logLevel: info          # debug|info|warn|error
+port: 8080              # overrides the default klaus-gateway listen port
+adapters:
+  slack:
+    enabled: true       # surfaced in `gateway status` under "Adapters"
+  github:
+    enabled: false
+agentGateway:
+  enabled: false        # auto-start agentgateway alongside klaus-gateway
+  port: 8090
+```
+
+## Auto-start on `klaus create`
+
+When the resolved instance config declares `requires.gateway.enabled: true`,
+`klausctl create` / `start` calls `gatewaybridge.EnsureRunning(...)` before
+the instance container starts. `klaus-gateway` is then reachable from the
+container at `http://host.docker.internal:<port>/mcp` via the standard
+`mcpServerRefs` flow.
+
+To also start agentgateway, set `requires.gateway.withAgentgateway: true`.
+
+```yaml
+# ~/.config/klausctl/instances/<name>/config.yaml
+requires:
+  gateway:
+    enabled: true
+    withAgentgateway: false
+```
+
+## Container networking
+
+Host-binary mode listens on `0.0.0.0` so containers reach it through the
+`--add-host host.docker.internal:host-gateway` plumbing klausctl already adds
+to `docker run` / `podman run`. On Linux, the extra-host flag is mandatory;
+macOS and Windows resolve `host.docker.internal` natively.
+
+## Troubleshooting
+
+**Stale PID file after an ungraceful shutdown.** `gateway status` detects a
+stale PID, removes the PID/port files, and reports `not running`. A fresh
+`gateway start` brings the bridge back up.
+
+**Port collision with an existing process.** Pass `--port <N>` (or set
+`port` in `gateway/config.yaml`) to pick a free port. The registered
+`mcpservers.yaml` entry is updated to match.
+
+**Container vs host-binary mismatch.** `gateway status` reports the start
+mode as `host` or `container` so you can tell which branch is active.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.48.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	golang.org/x/oauth2 v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -30,7 +31,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	gitlab.com/gitlab-org/api/client-go v1.9.1 // indirect

--- a/internal/gatewaysurface/surface.go
+++ b/internal/gatewaysurface/surface.go
@@ -1,0 +1,36 @@
+// Package gatewaysurface declares the public surface (flags and MCP inputs)
+// of the `klausctl gateway` command group.
+//
+// Both the Cobra command (cmd/gateway.go) and the MCP tool registration
+// (internal/tools/gateway) consume this package so the two surfaces cannot
+// drift. A parity test in cmd/gateway_parity_test.go asserts every CLI flag
+// has an MCP equivalent and vice versa.
+package gatewaysurface
+
+// Flag is a single CLI/MCP surface entry. CLIFlag is the Cobra flag name
+// (kebab-case), MCPKey is the MCP input parameter name (camelCase), Kind
+// names the value type ("bool", "int", "string"), and Description is the
+// human-readable summary shown in both surfaces.
+type Flag struct {
+	CLIFlag     string
+	MCPKey      string
+	Kind        string
+	Description string
+}
+
+// StartFlags lists the inputs accepted by `gateway start` and the
+// `klaus_gateway_start` MCP tool.
+var StartFlags = []Flag{
+	{CLIFlag: "with-agentgateway", MCPKey: "withAgentgateway", Kind: "bool", Description: "Also start agentgateway in front of klaus-gateway."},
+	{CLIFlag: "port", MCPKey: "port", Kind: "int", Description: "Override the klaus-gateway listen port."},
+	{CLIFlag: "agentgateway-port", MCPKey: "agentgatewayPort", Kind: "int", Description: "Override the agentgateway listen port."},
+	{CLIFlag: "klaus-gateway-bin", MCPKey: "klausGatewayBin", Kind: "string", Description: "Path to the klaus-gateway host binary (overrides KLAUS_GATEWAY_BIN)."},
+	{CLIFlag: "agentgateway-bin", MCPKey: "agentgatewayBin", Kind: "string", Description: "Path to the agentgateway host binary (overrides KLAUS_AGENTGATEWAY_BIN)."},
+	{CLIFlag: "log-level", MCPKey: "logLevel", Kind: "string", Description: "Gateway log level (debug, info, warn, error)."},
+}
+
+// StatusFlags lists the inputs accepted by `gateway status` and the
+// `klaus_gateway_status` MCP tool.
+var StatusFlags = []Flag{
+	{CLIFlag: "output", MCPKey: "output", Kind: "string", Description: `Output format: "text" (default) or "json".`},
+}

--- a/internal/tools/gateway/tools.go
+++ b/internal/tools/gateway/tools.go
@@ -1,0 +1,92 @@
+// Package gateway implements MCP tool handlers for klaus-gateway bridge
+// lifecycle management. The tool surface mirrors `klausctl gateway` exactly:
+// every CLI flag has an MCP input of the same shape, enforced by a parity
+// test in cmd/gateway_parity_test.go.
+package gateway
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/giantswarm/klausctl/internal/gatewaysurface"
+	"github.com/giantswarm/klausctl/internal/server"
+	"github.com/giantswarm/klausctl/pkg/gatewaybridge"
+)
+
+// RegisterTools registers klaus-gateway bridge lifecycle tools on the MCP server.
+func RegisterTools(s *mcpserver.MCPServer, sc *server.ServerContext) {
+	registerStart(s, sc)
+	registerStop(s, sc)
+	registerStatus(s, sc)
+}
+
+func registerStart(s *mcpserver.MCPServer, sc *server.ServerContext) {
+	opts := []mcp.ToolOption{
+		mcp.WithDescription("Start the klaus-gateway bridge. Launches the klaus-gateway process (and optionally agentgateway) in the background, writes PID/port files, health-checks /healthz, and auto-registers 'klaus-gateway' in the MCP server store."),
+	}
+	for _, f := range gatewaysurface.StartFlags {
+		opts = append(opts, mcpInputFor(f))
+	}
+	tool := mcp.NewTool("klaus_gateway_start", opts...)
+
+	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		bridgeOpts := gatewaybridge.Options{
+			WithAgentGateway: req.GetBool("withAgentgateway", false),
+			Port:             req.GetInt("port", 0),
+			AgentGatewayPort: req.GetInt("agentgatewayPort", 0),
+			KlausGatewayBin:  req.GetString("klausGatewayBin", ""),
+			AgentGatewayBin:  req.GetString("agentgatewayBin", ""),
+			LogLevel:         req.GetString("logLevel", ""),
+		}
+
+		st, err := gatewaybridge.Start(ctx, sc.Paths, bridgeOpts)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return server.JSONResult(st)
+	})
+}
+
+func registerStop(s *mcpserver.MCPServer, sc *server.ServerContext) {
+	tool := mcp.NewTool("klaus_gateway_stop",
+		mcp.WithDescription("Stop the running klaus-gateway bridge (and the agentgateway sidecar if it was started)."),
+	)
+	s.AddTool(tool, func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if err := gatewaybridge.Stop(ctx, sc.Paths); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return server.JSONResult(map[string]string{"status": "stopped"})
+	})
+}
+
+func registerStatus(s *mcpserver.MCPServer, sc *server.ServerContext) {
+	opts := []mcp.ToolOption{
+		mcp.WithDescription("Check the klaus-gateway bridge status. Returns the klaus-gateway process state (PID, port, URL, health), enabled adapters, and -- when started with agentgateway -- an agentGateway sub-status."),
+	}
+	for _, f := range gatewaysurface.StatusFlags {
+		opts = append(opts, mcpInputFor(f))
+	}
+	tool := mcp.NewTool("klaus_gateway_status", opts...)
+
+	s.AddTool(tool, func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// The status tool currently returns the same JSON shape regardless of
+		// the output value (MCP clients always consume JSON); the flag is
+		// accepted solely to preserve parity with the CLI surface.
+		_ = req.GetString("output", "")
+		st := gatewaybridge.GetStatus(sc.Paths)
+		return server.JSONResult(st)
+	})
+}
+
+func mcpInputFor(f gatewaysurface.Flag) mcp.ToolOption {
+	switch f.Kind {
+	case "bool":
+		return mcp.WithBoolean(f.MCPKey, mcp.Description(f.Description))
+	case "int":
+		return mcp.WithNumber(f.MCPKey, mcp.Description(f.Description))
+	default:
+		return mcp.WithString(f.MCPKey, mcp.Description(f.Description))
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,10 +107,31 @@ type Config struct {
 	// and merged into McpServers with a Bearer token header.
 	McpServerRefs []string `yaml:"mcpServerRefs,omitempty"`
 
+	// Requires declares runtime services this instance depends on. When set,
+	// `klausctl create` / `start` auto-starts those services before starting
+	// the instance container. See pkg/gatewaybridge for the gateway bridge.
+	Requires Requires `yaml:"requires,omitempty"`
+
 	// imageFromConfig tracks whether Image was explicitly set in the config
 	// file before defaults were applied. Used by personality merging to
 	// determine whether the personality's image should take effect.
 	imageFromConfig bool
+}
+
+// Requires declares the local services that must be running before the
+// instance can start. klausctl owns the lifecycle of each listed service.
+type Requires struct {
+	// Gateway configures the klaus-gateway dependency. When Enabled, the
+	// gatewaybridge is auto-started before the instance container.
+	Gateway GatewayRequirement `yaml:"gateway,omitempty"`
+}
+
+// GatewayRequirement is the klaus-gateway block of Requires.
+type GatewayRequirement struct {
+	// Enabled triggers auto-start of the klaus-gateway bridge.
+	Enabled bool `yaml:"enabled,omitempty"`
+	// WithAgentGateway also starts agentgateway in front of klaus-gateway.
+	WithAgentGateway bool `yaml:"withAgentgateway,omitempty"`
 }
 
 // ImageExplicitlySet reports whether the Image field was explicitly set in the

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -51,6 +51,27 @@ type Paths struct {
 	MusterPIDFile string
 	// MusterPortFile tracks the port of the managed muster process.
 	MusterPortFile string
+	// GatewayConfigDir is the user-owned klaus-gateway config root
+	// (~/.config/klausctl/gateway/). Contains config.yaml, routes.bolt, and
+	// slack-secrets.yaml.
+	GatewayConfigDir string
+	// GatewayConfigFile is the user-owned gateway/config.yaml
+	// (~/.config/klausctl/gateway/config.yaml).
+	GatewayConfigFile string
+	// GatewayRoutesBoltFile is the klausctl-owned routes store passed to
+	// klaus-gateway as --bolt-path (~/.config/klausctl/gateway/routes.bolt).
+	GatewayRoutesBoltFile string
+	// GatewaySlackSecretsFile is the user-owned slack adapter secrets file
+	// (~/.config/klausctl/gateway/slack-secrets.yaml).
+	GatewaySlackSecretsFile string
+	// KlausGatewayPIDFile tracks the PID of the managed klaus-gateway process.
+	KlausGatewayPIDFile string
+	// KlausGatewayPortFile tracks the port of the managed klaus-gateway process.
+	KlausGatewayPortFile string
+	// AgentGatewayPIDFile tracks the PID of the managed agentgateway process.
+	AgentGatewayPIDFile string
+	// AgentGatewayPortFile tracks the port of the managed agentgateway process.
+	AgentGatewayPortFile string
 	// ReposDir is the managed repo cache directory (~/.config/klausctl/repos/).
 	ReposDir string
 	// WorkspacesFile is the path to the workspace registry (~/.config/klausctl/workspaces.yaml).
@@ -75,28 +96,37 @@ func DefaultPaths() (*Paths, error) {
 	}
 
 	musterDir := filepath.Join(base, "muster")
+	gatewayDir := filepath.Join(base, "gateway")
 
 	return &Paths{
-		ConfigDir:           base,
-		ConfigFile:          filepath.Join(defaultInstanceDir, "config.yaml"),
-		InstancesDir:        instancesDir,
-		InstanceDir:         defaultInstanceDir,
-		RenderedDir:         filepath.Join(defaultInstanceDir, "rendered"),
-		ExtensionsDir:       filepath.Join(defaultInstanceDir, "rendered", "extensions"),
-		PluginsDir:          filepath.Join(base, "plugins"),
-		PersonalitiesDir:    filepath.Join(base, "personalities"),
-		InstanceFile:        filepath.Join(defaultInstanceDir, "instance.json"),
-		ArchivesDir:         filepath.Join(base, "archives"),
-		TokensDir:           filepath.Join(base, "tokens"),
-		SecretsFile:         filepath.Join(base, "secrets.yaml"),
-		McpServersFile:      filepath.Join(base, "mcpservers.yaml"),
-		SourcesFile:         sourcesFile,
-		MusterConfigDir:     musterDir,
-		MusterMCPServersDir: filepath.Join(musterDir, "mcpservers"),
-		MusterPIDFile:       filepath.Join(base, "muster.pid"),
-		MusterPortFile:      filepath.Join(base, "muster.port"),
-		ReposDir:            filepath.Join(base, "repos"),
-		WorkspacesFile:      filepath.Join(base, "workspaces.yaml"),
+		ConfigDir:               base,
+		ConfigFile:              filepath.Join(defaultInstanceDir, "config.yaml"),
+		InstancesDir:            instancesDir,
+		InstanceDir:             defaultInstanceDir,
+		RenderedDir:             filepath.Join(defaultInstanceDir, "rendered"),
+		ExtensionsDir:           filepath.Join(defaultInstanceDir, "rendered", "extensions"),
+		PluginsDir:              filepath.Join(base, "plugins"),
+		PersonalitiesDir:        filepath.Join(base, "personalities"),
+		InstanceFile:            filepath.Join(defaultInstanceDir, "instance.json"),
+		ArchivesDir:             filepath.Join(base, "archives"),
+		TokensDir:               filepath.Join(base, "tokens"),
+		SecretsFile:             filepath.Join(base, "secrets.yaml"),
+		McpServersFile:          filepath.Join(base, "mcpservers.yaml"),
+		SourcesFile:             sourcesFile,
+		MusterConfigDir:         musterDir,
+		MusterMCPServersDir:     filepath.Join(musterDir, "mcpservers"),
+		MusterPIDFile:           filepath.Join(base, "muster.pid"),
+		MusterPortFile:          filepath.Join(base, "muster.port"),
+		GatewayConfigDir:        gatewayDir,
+		GatewayConfigFile:       filepath.Join(gatewayDir, "config.yaml"),
+		GatewayRoutesBoltFile:   filepath.Join(gatewayDir, "routes.bolt"),
+		GatewaySlackSecretsFile: filepath.Join(gatewayDir, "slack-secrets.yaml"),
+		KlausGatewayPIDFile:     filepath.Join(base, "klaus-gateway.pid"),
+		KlausGatewayPortFile:    filepath.Join(base, "klaus-gateway.port"),
+		AgentGatewayPIDFile:     filepath.Join(base, "agentgateway.pid"),
+		AgentGatewayPortFile:    filepath.Join(base, "agentgateway.port"),
+		ReposDir:                filepath.Join(base, "repos"),
+		WorkspacesFile:          filepath.Join(base, "workspaces.yaml"),
 	}, nil
 }
 
@@ -152,26 +182,34 @@ func (p *Paths) ForInstance(name string) *Paths {
 
 	instDir := filepath.Join(p.InstancesDir, instanceName)
 	return &Paths{
-		ConfigDir:           p.ConfigDir,
-		ConfigFile:          filepath.Join(instDir, "config.yaml"),
-		InstancesDir:        p.InstancesDir,
-		InstanceDir:         instDir,
-		RenderedDir:         filepath.Join(instDir, "rendered"),
-		ExtensionsDir:       filepath.Join(instDir, "rendered", "extensions"),
-		PluginsDir:          p.PluginsDir,
-		PersonalitiesDir:    p.PersonalitiesDir,
-		InstanceFile:        filepath.Join(instDir, "instance.json"),
-		ArchivesDir:         p.ArchivesDir,
-		TokensDir:           p.TokensDir,
-		SecretsFile:         p.SecretsFile,
-		McpServersFile:      p.McpServersFile,
-		SourcesFile:         p.SourcesFile,
-		MusterConfigDir:     p.MusterConfigDir,
-		MusterMCPServersDir: p.MusterMCPServersDir,
-		MusterPIDFile:       p.MusterPIDFile,
-		MusterPortFile:      p.MusterPortFile,
-		ReposDir:            p.ReposDir,
-		WorkspacesFile:      p.WorkspacesFile,
+		ConfigDir:               p.ConfigDir,
+		ConfigFile:              filepath.Join(instDir, "config.yaml"),
+		InstancesDir:            p.InstancesDir,
+		InstanceDir:             instDir,
+		RenderedDir:             filepath.Join(instDir, "rendered"),
+		ExtensionsDir:           filepath.Join(instDir, "rendered", "extensions"),
+		PluginsDir:              p.PluginsDir,
+		PersonalitiesDir:        p.PersonalitiesDir,
+		InstanceFile:            filepath.Join(instDir, "instance.json"),
+		ArchivesDir:             p.ArchivesDir,
+		TokensDir:               p.TokensDir,
+		SecretsFile:             p.SecretsFile,
+		McpServersFile:          p.McpServersFile,
+		SourcesFile:             p.SourcesFile,
+		MusterConfigDir:         p.MusterConfigDir,
+		MusterMCPServersDir:     p.MusterMCPServersDir,
+		MusterPIDFile:           p.MusterPIDFile,
+		MusterPortFile:          p.MusterPortFile,
+		GatewayConfigDir:        p.GatewayConfigDir,
+		GatewayConfigFile:       p.GatewayConfigFile,
+		GatewayRoutesBoltFile:   p.GatewayRoutesBoltFile,
+		GatewaySlackSecretsFile: p.GatewaySlackSecretsFile,
+		KlausGatewayPIDFile:     p.KlausGatewayPIDFile,
+		KlausGatewayPortFile:    p.KlausGatewayPortFile,
+		AgentGatewayPIDFile:     p.AgentGatewayPIDFile,
+		AgentGatewayPortFile:    p.AgentGatewayPortFile,
+		ReposDir:                p.ReposDir,
+		WorkspacesFile:          p.WorkspacesFile,
 	}
 }
 

--- a/pkg/gatewaybridge/agentgateway.go
+++ b/pkg/gatewaybridge/agentgateway.go
@@ -1,0 +1,90 @@
+package gatewaybridge
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+)
+
+const (
+	// agentGatewayBinEnv names the env var that overrides the agentgateway
+	// host binary path.
+	agentGatewayBinEnv = "KLAUS_AGENTGATEWAY_BIN"
+)
+
+// startAgentGateway spawns the optional agentgateway process. It is started
+// before klaus-gateway so klaus-gateway can point at it via --agentgateway-url.
+func startAgentGateway(ctx context.Context, paths *config.Paths, opts Options, cfg gatewayConfig) (*AgentGatewayState, error) {
+	port := firstNonZero(opts.AgentGatewayPort, cfg.AgentGateway.Port, DefaultAgentGatewayPort)
+
+	bin := opts.AgentGatewayBin
+	if bin == "" {
+		bin = os.Getenv(agentGatewayBinEnv)
+	}
+	if bin == "" {
+		if p, err := exec.LookPath("agentgateway"); err == nil {
+			bin = p
+		}
+	}
+	if bin == "" {
+		return nil, fmt.Errorf("agentgateway not found: set %s or --agentgateway-bin, or install agentgateway on PATH", agentGatewayBinEnv)
+	}
+
+	args := []string{
+		fmt.Sprintf("--listen-address=:%d", port),
+	}
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	setSysProcAttr(cmd)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting agentgateway: %w", err)
+	}
+
+	pid := cmd.Process.Pid
+	if err := writePID(paths.AgentGatewayPIDFile, pid); err != nil {
+		return nil, fmt.Errorf("writing agentgateway PID file: %w", err)
+	}
+	if err := writePort(paths.AgentGatewayPortFile, port); err != nil {
+		return nil, fmt.Errorf("writing agentgateway port file: %w", err)
+	}
+	if err := writeMode(paths.AgentGatewayPIDFile, "host"); err != nil {
+		return nil, fmt.Errorf("writing agentgateway mode file: %w", err)
+	}
+
+	if err := cmd.Process.Release(); err != nil {
+		return nil, fmt.Errorf("releasing agentgateway process: %w", err)
+	}
+
+	if err := waitHealthy(ctx, port); err != nil {
+		return nil, fmt.Errorf("agentgateway started (PID %d) but did not become healthy: %w", pid, err)
+	}
+
+	return &AgentGatewayState{
+		Running: true,
+		PID:     pid,
+		Port:    port,
+		URL:     fmt.Sprintf("http://localhost:%d", port),
+		Healthy: true,
+		Mode:    "host",
+	}, nil
+}
+
+// stopAgentGateway terminates the agentgateway process and removes its
+// PID/port files. Returns nil when no PID file is present (idempotent).
+func stopAgentGateway(paths *config.Paths) error {
+	pid, err := readPID(paths.AgentGatewayPIDFile)
+	if err != nil {
+		return nil
+	}
+	if err := stopProcess(pid); err != nil {
+		return fmt.Errorf("stopping agentgateway: %w", err)
+	}
+	cleanupAgentGatewayFiles(paths)
+	return nil
+}

--- a/pkg/gatewaybridge/bridge.go
+++ b/pkg/gatewaybridge/bridge.go
@@ -1,0 +1,305 @@
+// Package gatewaybridge manages the local lifecycle of the klaus-gateway
+// service (and optionally the upstream agentgateway it can run behind).
+// It mirrors the shape of pkg/musterbridge: klausctl spawns the processes,
+// tracks their PID/port, registers the HTTP MCP endpoint into mcpservers.yaml,
+// and auto-starts on `klaus create` when a personality/instance declares
+// `requires.gateway: true`.
+package gatewaybridge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/mcpserverstore"
+)
+
+const (
+	// BridgeName is the name used when registering klaus-gateway in the
+	// MCP server store.
+	BridgeName = "klaus-gateway"
+
+	// DefaultKlausGatewayPort is the default port for klaus-gateway.
+	DefaultKlausGatewayPort = 8080
+	// DefaultAgentGatewayPort is the default port for the optional agentgateway.
+	DefaultAgentGatewayPort = 8090
+)
+
+// Options configures the bridge lifecycle. All fields are optional; zero
+// values fall back to defaults or values read from gateway/config.yaml.
+type Options struct {
+	// WithAgentGateway, when true, also starts the agentgateway process
+	// before starting klaus-gateway.
+	WithAgentGateway bool
+
+	// Port overrides the klaus-gateway listen port.
+	Port int
+
+	// AgentGatewayPort overrides the agentgateway listen port.
+	AgentGatewayPort int
+
+	// KlausGatewayBin overrides the klaus-gateway host binary path.
+	// If empty, the KLAUS_GATEWAY_BIN env var is consulted, then PATH.
+	KlausGatewayBin string
+
+	// AgentGatewayBin overrides the agentgateway host binary path.
+	// If empty, the KLAUS_AGENTGATEWAY_BIN env var is consulted, then PATH.
+	AgentGatewayBin string
+
+	// LogLevel overrides the gateway log level (defaults to "info").
+	LogLevel string
+}
+
+// Status represents the state of the gateway bridge.
+type Status struct {
+	Running          bool               `json:"running"`
+	PID              int                `json:"pid,omitempty"`
+	Port             int                `json:"port,omitempty"`
+	URL              string             `json:"url,omitempty"`
+	Healthy          bool               `json:"healthy"`
+	Mode             string             `json:"mode,omitempty"`
+	Adapters         []string           `json:"adapters,omitempty"`
+	WithAgentGateway bool               `json:"withAgentGateway,omitempty"`
+	AgentGateway     *AgentGatewayState `json:"agentGateway,omitempty"`
+}
+
+// AgentGatewayState describes the agentgateway process state as a sub-status.
+type AgentGatewayState struct {
+	Running bool   `json:"running"`
+	PID     int    `json:"pid,omitempty"`
+	Port    int    `json:"port,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Healthy bool   `json:"healthy"`
+	Mode    string `json:"mode,omitempty"`
+}
+
+// Start launches the klaus-gateway process (and optionally agentgateway) in
+// the background. It is idempotent: if klaus-gateway is already running and
+// healthy, it returns the existing status.
+func Start(ctx context.Context, paths *config.Paths, opts Options) (*Status, error) {
+	if st, alive := checkRunning(paths, opts); alive {
+		if err := registerBridge(paths, st.Port); err != nil {
+			return nil, fmt.Errorf("registering klaus-gateway in mcpserverstore: %w", err)
+		}
+		return st, nil
+	}
+
+	cfg := loadGatewayConfig(paths.GatewayConfigFile)
+
+	// Ensure the routes.bolt parent directory exists (klausctl-owned).
+	if err := os.MkdirAll(paths.GatewayConfigDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating gateway config dir: %w", err)
+	}
+
+	withAgentGW := opts.WithAgentGateway || cfg.AgentGateway.Enabled
+
+	var agentStatus *AgentGatewayState
+	agentGatewayURL := ""
+	if withAgentGW {
+		st, err := startAgentGateway(ctx, paths, opts, cfg)
+		if err != nil {
+			return nil, err
+		}
+		agentStatus = st
+		agentGatewayURL = fmt.Sprintf("http://localhost:%d", st.Port)
+	}
+
+	gwStatus, err := startKlausGateway(ctx, paths, opts, cfg, agentGatewayURL)
+	if err != nil {
+		// Roll back agentgateway if we started it in this call.
+		if withAgentGW {
+			_ = stopAgentGateway(paths)
+		}
+		return nil, err
+	}
+
+	if err := registerBridge(paths, gwStatus.Port); err != nil {
+		return nil, fmt.Errorf("registering klaus-gateway in mcpserverstore: %w", err)
+	}
+
+	gwStatus.WithAgentGateway = withAgentGW
+	gwStatus.AgentGateway = agentStatus
+	gwStatus.Adapters = cfg.EnabledAdapters()
+	return gwStatus, nil
+}
+
+// Stop terminates klaus-gateway first, then agentgateway if running, cleans
+// up PID/port files, and removes the klaus-gateway entry from mcpservers.yaml.
+func Stop(ctx context.Context, paths *config.Paths) error {
+	_ = ctx // reserved for future cancellation support
+
+	gwErr := stopKlausGateway(paths)
+	agErr := stopAgentGateway(paths)
+
+	deregisterBridge(paths)
+
+	if gwErr != nil {
+		return gwErr
+	}
+	return agErr
+}
+
+// GetStatus returns the current bridge status without mutating any state.
+func GetStatus(paths *config.Paths) *Status {
+	st, alive := checkRunning(paths, Options{})
+	if !alive {
+		return &Status{Running: false}
+	}
+	return st
+}
+
+// EnsureRunning starts the bridge if it is not already running, otherwise
+// ensures the bridge entry exists in the MCP server store. Used by the
+// auto-start integration in the instance start flow.
+func EnsureRunning(ctx context.Context, paths *config.Paths, opts Options) (*Status, error) {
+	if st, alive := checkRunning(paths, opts); alive {
+		if err := registerBridge(paths, st.Port); err != nil {
+			return nil, fmt.Errorf("registering klaus-gateway in mcpserverstore: %w", err)
+		}
+		return st, nil
+	}
+	return Start(ctx, paths, opts)
+}
+
+// Restart stops and re-starts the bridge. Useful after config changes.
+func Restart(ctx context.Context, paths *config.Paths, opts Options) (*Status, error) {
+	_ = Stop(ctx, paths)
+	return Start(ctx, paths, opts)
+}
+
+// checkRunning returns the current status iff klaus-gateway's PID file points
+// at a live process. Stale PID files are cleaned up as a side effect.
+func checkRunning(paths *config.Paths, opts Options) (*Status, bool) {
+	pid, err := readPID(paths.KlausGatewayPIDFile)
+	if err != nil {
+		return nil, false
+	}
+	if !processAlive(pid) {
+		cleanupKlausGatewayFiles(paths)
+		return nil, false
+	}
+
+	port, err := readPort(paths.KlausGatewayPortFile)
+	if err != nil {
+		port = DefaultKlausGatewayPort
+	}
+
+	cfg := loadGatewayConfig(paths.GatewayConfigFile)
+
+	st := &Status{
+		Running:  true,
+		PID:      pid,
+		Port:     port,
+		URL:      bridgeURL(port),
+		Healthy:  healthyNow(port),
+		Mode:     modeLabel(paths.KlausGatewayPIDFile),
+		Adapters: cfg.EnabledAdapters(),
+	}
+
+	// Also attach agentgateway state when present.
+	if ag, ok := checkAgentGatewayRunning(paths); ok {
+		st.WithAgentGateway = true
+		st.AgentGateway = ag
+	} else if opts.WithAgentGateway {
+		st.WithAgentGateway = true
+	}
+
+	return st, true
+}
+
+// checkAgentGatewayRunning reports the current agentgateway sub-status.
+func checkAgentGatewayRunning(paths *config.Paths) (*AgentGatewayState, bool) {
+	pid, err := readPID(paths.AgentGatewayPIDFile)
+	if err != nil {
+		return nil, false
+	}
+	if !processAlive(pid) {
+		cleanupAgentGatewayFiles(paths)
+		return nil, false
+	}
+	port, err := readPort(paths.AgentGatewayPortFile)
+	if err != nil {
+		port = DefaultAgentGatewayPort
+	}
+	return &AgentGatewayState{
+		Running: true,
+		PID:     pid,
+		Port:    port,
+		URL:     fmt.Sprintf("http://localhost:%d", port),
+		Healthy: healthyNow(port),
+		Mode:    modeLabel(paths.AgentGatewayPIDFile),
+	}, true
+}
+
+// bridgeURL is the URL the klaus-gateway MCP endpoint is registered under.
+// Matches the musterbridge convention so containers can reach it via
+// host.docker.internal.
+func bridgeURL(port int) string {
+	return fmt.Sprintf("http://host.docker.internal:%d/mcp", port)
+}
+
+func registerBridge(paths *config.Paths, port int) error {
+	store, err := mcpserverstore.Load(paths.McpServersFile)
+	if err != nil {
+		return err
+	}
+	store.Add(BridgeName, mcpserverstore.McpServerDef{URL: bridgeURL(port)})
+	return store.Save()
+}
+
+func deregisterBridge(paths *config.Paths) {
+	store, err := mcpserverstore.Load(paths.McpServersFile)
+	if err != nil {
+		return
+	}
+	if err := store.Remove(BridgeName); err != nil {
+		return
+	}
+	_ = store.Save()
+}
+
+func cleanupKlausGatewayFiles(paths *config.Paths) {
+	_ = os.Remove(paths.KlausGatewayPIDFile)
+	_ = os.Remove(paths.KlausGatewayPortFile)
+	_ = os.Remove(modePath(paths.KlausGatewayPIDFile))
+}
+
+func cleanupAgentGatewayFiles(paths *config.Paths) {
+	_ = os.Remove(paths.AgentGatewayPIDFile)
+	_ = os.Remove(paths.AgentGatewayPortFile)
+	_ = os.Remove(modePath(paths.AgentGatewayPIDFile))
+}
+
+// waitForExit polls until the process exits or the deadline passes. Returns
+// true if the process has exited.
+func waitForExit(pid int, deadline time.Duration) bool {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if !processAlive(pid) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}
+
+// stopProcess signals proc SIGTERM, waits up to 5s, then SIGKILLs if needed.
+func stopProcess(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return nil
+	}
+	if err := sendTermSignal(proc); err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			return nil
+		}
+		return fmt.Errorf("SIGTERM pid %d: %w", pid, err)
+	}
+	if !waitForExit(pid, 5*time.Second) {
+		_ = sendKillSignal(proc)
+	}
+	return nil
+}

--- a/pkg/gatewaybridge/bridge_test.go
+++ b/pkg/gatewaybridge/bridge_test.go
@@ -1,0 +1,324 @@
+package gatewaybridge
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/mcpserverstore"
+)
+
+func testPaths(t *testing.T) *config.Paths {
+	t.Helper()
+	dir := t.TempDir()
+	gatewayDir := filepath.Join(dir, "gateway")
+	if err := os.MkdirAll(gatewayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return &config.Paths{
+		ConfigDir:               dir,
+		McpServersFile:          filepath.Join(dir, "mcpservers.yaml"),
+		GatewayConfigDir:        gatewayDir,
+		GatewayConfigFile:       filepath.Join(gatewayDir, "config.yaml"),
+		GatewayRoutesBoltFile:   filepath.Join(gatewayDir, "routes.bolt"),
+		GatewaySlackSecretsFile: filepath.Join(gatewayDir, "slack-secrets.yaml"),
+		KlausGatewayPIDFile:     filepath.Join(dir, "klaus-gateway.pid"),
+		KlausGatewayPortFile:    filepath.Join(dir, "klaus-gateway.port"),
+		AgentGatewayPIDFile:     filepath.Join(dir, "agentgateway.pid"),
+		AgentGatewayPortFile:    filepath.Join(dir, "agentgateway.port"),
+	}
+}
+
+func TestBridgeURL(t *testing.T) {
+	got := bridgeURL(8080)
+	want := "http://host.docker.internal:8080/mcp"
+	if got != want {
+		t.Errorf("bridgeURL(8080) = %q, want %q", got, want)
+	}
+}
+
+func TestGetStatus_NotRunning(t *testing.T) {
+	paths := testPaths(t)
+	st := GetStatus(paths)
+	if st.Running {
+		t.Error("expected Running=false when no PID file is present")
+	}
+}
+
+func TestGetStatus_StalePID(t *testing.T) {
+	paths := testPaths(t)
+	if err := os.WriteFile(paths.KlausGatewayPIDFile, []byte("999999999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	st := GetStatus(paths)
+	if st.Running {
+		t.Error("expected Running=false for stale PID")
+	}
+	if _, err := os.Stat(paths.KlausGatewayPIDFile); !os.IsNotExist(err) {
+		t.Error("expected stale klaus-gateway PID file to be cleaned up")
+	}
+}
+
+func TestRegisterBridge(t *testing.T) {
+	paths := testPaths(t)
+	if err := registerBridge(paths, 8080); err != nil {
+		t.Fatalf("registerBridge: %v", err)
+	}
+	store, err := mcpserverstore.Load(paths.McpServersFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	def, err := store.Get(BridgeName)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", BridgeName, err)
+	}
+	want := "http://host.docker.internal:8080/mcp"
+	if def.URL != want {
+		t.Errorf("URL = %q, want %q", def.URL, want)
+	}
+}
+
+func TestRegisterBridge_Idempotent(t *testing.T) {
+	paths := testPaths(t)
+	for i := 0; i < 3; i++ {
+		if err := registerBridge(paths, 8080); err != nil {
+			t.Fatalf("registerBridge (call %d): %v", i+1, err)
+		}
+	}
+	store, err := mcpserverstore.Load(paths.McpServersFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	names := store.List()
+	if len(names) != 1 {
+		t.Errorf("expected 1 entry, got %d: %v", len(names), names)
+	}
+}
+
+func TestRegisterBridge_UpdatesPort(t *testing.T) {
+	paths := testPaths(t)
+	if err := registerBridge(paths, 8080); err != nil {
+		t.Fatalf("registerBridge(8080): %v", err)
+	}
+	if err := registerBridge(paths, 9999); err != nil {
+		t.Fatalf("registerBridge(9999): %v", err)
+	}
+	store, err := mcpserverstore.Load(paths.McpServersFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	def, err := store.Get(BridgeName)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	want := "http://host.docker.internal:9999/mcp"
+	if def.URL != want {
+		t.Errorf("URL = %q, want %q", def.URL, want)
+	}
+}
+
+func TestDeregisterBridge_PreservesOthers(t *testing.T) {
+	paths := testPaths(t)
+	store, err := mcpserverstore.Load(paths.McpServersFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	store.Add("other", mcpserverstore.McpServerDef{URL: "https://other.example.com/mcp"})
+	store.Add(BridgeName, mcpserverstore.McpServerDef{URL: bridgeURL(8080)})
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	deregisterBridge(paths)
+
+	reloaded, err := mcpserverstore.Load(paths.McpServersFile)
+	if err != nil {
+		t.Fatalf("Load after deregister: %v", err)
+	}
+	if _, err := reloaded.Get("other"); err != nil {
+		t.Error("unrelated MCP server entry should be preserved")
+	}
+	if _, err := reloaded.Get(BridgeName); err == nil {
+		t.Error("klaus-gateway should be removed after deregisterBridge")
+	}
+}
+
+func TestDeregisterBridge_NoEntry(t *testing.T) {
+	paths := testPaths(t)
+	deregisterBridge(paths) // must not panic or error
+}
+
+func TestLoadGatewayConfig_Missing(t *testing.T) {
+	paths := testPaths(t)
+	cfg := loadGatewayConfig(paths.GatewayConfigFile)
+	if cfg.Port != 0 {
+		t.Errorf("expected zero port for missing config, got %d", cfg.Port)
+	}
+	if len(cfg.EnabledAdapters()) != 0 {
+		t.Errorf("expected no adapters for missing config, got %v", cfg.EnabledAdapters())
+	}
+}
+
+func TestLoadGatewayConfig_Parses(t *testing.T) {
+	paths := testPaths(t)
+	content := []byte(`logLevel: debug
+port: 9100
+adapters:
+  slack:
+    enabled: true
+  github:
+    enabled: false
+agentGateway:
+  enabled: true
+  port: 9200
+`)
+	if err := os.WriteFile(paths.GatewayConfigFile, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := loadGatewayConfig(paths.GatewayConfigFile)
+	if cfg.LogLevel != "debug" {
+		t.Errorf("LogLevel = %q, want debug", cfg.LogLevel)
+	}
+	if cfg.Port != 9100 {
+		t.Errorf("Port = %d, want 9100", cfg.Port)
+	}
+	if !cfg.AgentGateway.Enabled {
+		t.Error("expected AgentGateway.Enabled=true")
+	}
+	if cfg.AgentGateway.Port != 9200 {
+		t.Errorf("AgentGateway.Port = %d, want 9200", cfg.AgentGateway.Port)
+	}
+	got := cfg.EnabledAdapters()
+	if len(got) != 1 || got[0] != "slack" {
+		t.Errorf("EnabledAdapters = %v, want [slack]", got)
+	}
+}
+
+func TestFirstNonZero(t *testing.T) {
+	if v := firstNonZero(0, 0, 42, 7); v != 42 {
+		t.Errorf("firstNonZero(0,0,42,7) = %d, want 42", v)
+	}
+	if v := firstNonZero(0, 0, 0); v != 0 {
+		t.Errorf("firstNonZero(0,0,0) = %d, want 0", v)
+	}
+	if v := firstNonZero(); v != 0 {
+		t.Errorf("firstNonZero() = %d, want 0", v)
+	}
+}
+
+func TestStart_NoBinary(t *testing.T) {
+	paths := testPaths(t)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv(klausGatewayBinEnv, "")
+	_, err := Start(context.Background(), paths, Options{})
+	if err == nil {
+		t.Fatal("expected error when klaus-gateway binary is not available")
+	}
+}
+
+func TestEnsureRunning_NoBinary(t *testing.T) {
+	paths := testPaths(t)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv(klausGatewayBinEnv, "")
+	_, err := EnsureRunning(context.Background(), paths, Options{})
+	if err == nil {
+		t.Fatal("expected error when klaus-gateway binary is not available")
+	}
+}
+
+// TestOwnership asserts the strict file ownership boundary: klausctl writes
+// to *.pid, *.port, routes.bolt; never to gateway/config.yaml or
+// gateway/slack-secrets.yaml.
+func TestOwnership(t *testing.T) {
+	paths := testPaths(t)
+
+	// Write klausctl-owned files via the helpers.
+	if err := writePID(paths.KlausGatewayPIDFile, 1234); err != nil {
+		t.Fatalf("writePID: %v", err)
+	}
+	if err := writePort(paths.KlausGatewayPortFile, 8080); err != nil {
+		t.Fatalf("writePort: %v", err)
+	}
+	if err := writePID(paths.AgentGatewayPIDFile, 5678); err != nil {
+		t.Fatalf("writePID agent: %v", err)
+	}
+	if err := writePort(paths.AgentGatewayPortFile, 8090); err != nil {
+		t.Fatalf("writePort agent: %v", err)
+	}
+
+	// User-owned files are never touched by klausctl: create them by hand
+	// and confirm cleanup does not remove them.
+	if err := os.WriteFile(paths.GatewayConfigFile, []byte("logLevel: info\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.GatewaySlackSecretsFile, []byte("token: placeholder\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanupKlausGatewayFiles(paths)
+	cleanupAgentGatewayFiles(paths)
+
+	// klausctl-owned files should be gone.
+	for _, p := range []string{
+		paths.KlausGatewayPIDFile,
+		paths.KlausGatewayPortFile,
+		paths.AgentGatewayPIDFile,
+		paths.AgentGatewayPortFile,
+	} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("expected klausctl-owned file %s removed, err=%v", p, err)
+		}
+	}
+
+	// User-owned files must be untouched.
+	if _, err := os.Stat(paths.GatewayConfigFile); err != nil {
+		t.Errorf("user-owned gateway/config.yaml should be preserved: %v", err)
+	}
+	if _, err := os.Stat(paths.GatewaySlackSecretsFile); err != nil {
+		t.Errorf("user-owned gateway/slack-secrets.yaml should be preserved: %v", err)
+	}
+}
+
+func TestStop_NoPIDFile(t *testing.T) {
+	paths := testPaths(t)
+	// No PID files exist -- Stop is idempotent and returns nil.
+	if err := Stop(context.Background(), paths); err != nil {
+		t.Errorf("Stop with no PID files returned error: %v", err)
+	}
+}
+
+func TestStop_CleansStaleFiles(t *testing.T) {
+	paths := testPaths(t)
+
+	// Simulate stale state: PID files point at non-existent PIDs.
+	if err := writePID(paths.KlausGatewayPIDFile, 999999999); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePort(paths.KlausGatewayPortFile, 8080); err != nil {
+		t.Fatal(err)
+	}
+	// Register an mcpservers.yaml entry to confirm deregistration.
+	if err := registerBridge(paths, 8080); err != nil {
+		t.Fatalf("registerBridge: %v", err)
+	}
+
+	if err := Stop(context.Background(), paths); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if _, err := os.Stat(paths.KlausGatewayPIDFile); !os.IsNotExist(err) {
+		t.Error("expected klaus-gateway PID file removed after Stop")
+	}
+	if _, err := os.Stat(paths.KlausGatewayPortFile); !os.IsNotExist(err) {
+		t.Error("expected klaus-gateway port file removed after Stop")
+	}
+	store, err := mcpserverstore.Load(paths.McpServersFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, err := store.Get(BridgeName); err == nil {
+		t.Error("expected klaus-gateway removed from mcpservers.yaml after Stop")
+	}
+}

--- a/pkg/gatewaybridge/config.go
+++ b/pkg/gatewaybridge/config.go
@@ -1,0 +1,62 @@
+package gatewaybridge
+
+import (
+	"os"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// gatewayConfig is the subset of gateway/config.yaml that klausctl reads.
+// The file is user-owned: klausctl never writes to it.
+type gatewayConfig struct {
+	// LogLevel configures the --log-level flag passed to klaus-gateway.
+	LogLevel string `yaml:"logLevel,omitempty"`
+	// Port overrides the klaus-gateway listen port.
+	Port int `yaml:"port,omitempty"`
+	// Adapters toggles per-channel adapters. Keys are adapter names (e.g.
+	// "slack"), values are a small config struct. The set of enabled
+	// adapters is surfaced in the Status payload.
+	Adapters map[string]adapterConfig `yaml:"adapters,omitempty"`
+	// AgentGateway configures the optional upstream wire-format proxy.
+	AgentGateway agentGatewayConfig `yaml:"agentGateway,omitempty"`
+}
+
+type adapterConfig struct {
+	Enabled bool `yaml:"enabled,omitempty"`
+}
+
+type agentGatewayConfig struct {
+	Enabled bool `yaml:"enabled,omitempty"`
+	Port    int  `yaml:"port,omitempty"`
+}
+
+// loadGatewayConfig reads and parses the gateway/config.yaml file. A missing
+// or unreadable file yields a zero config (all defaults).
+func loadGatewayConfig(path string) gatewayConfig {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return gatewayConfig{}
+	}
+	var gc gatewayConfig
+	if err := yaml.Unmarshal(data, &gc); err != nil {
+		return gatewayConfig{}
+	}
+	return gc
+}
+
+// EnabledAdapters returns the sorted names of adapters with `enabled: true`
+// in gateway/config.yaml.
+func (c gatewayConfig) EnabledAdapters() []string {
+	if len(c.Adapters) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(c.Adapters))
+	for name, ac := range c.Adapters {
+		if ac.Enabled {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/gatewaybridge/gateway.go
+++ b/pkg/gatewaybridge/gateway.go
@@ -1,0 +1,152 @@
+package gatewaybridge
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+)
+
+const (
+	// klausGatewayBinEnv names the env var that overrides the klaus-gateway
+	// host binary path.
+	klausGatewayBinEnv = "KLAUS_GATEWAY_BIN"
+)
+
+// startKlausGateway spawns the klaus-gateway process in host-binary mode
+// when KLAUS_GATEWAY_BIN (or --klaus-gateway-bin) resolves, and in container
+// mode otherwise. Returns the in-progress status, already health-checked.
+func startKlausGateway(ctx context.Context, paths *config.Paths, opts Options, cfg gatewayConfig, agentGatewayURL string) (*Status, error) {
+	port := firstNonZero(opts.Port, cfg.Port, DefaultKlausGatewayPort)
+
+	bin := opts.KlausGatewayBin
+	if bin == "" {
+		bin = os.Getenv(klausGatewayBinEnv)
+	}
+
+	mode := "host"
+	if bin == "" {
+		// Fall back to a binary on PATH; if still missing, we cannot start
+		// container mode from this PR (see docs/gatewaybridge.md) and must
+		// error loudly.
+		if p, err := exec.LookPath("klaus-gateway"); err == nil {
+			bin = p
+		}
+	}
+
+	if bin == "" {
+		return nil, fmt.Errorf("klaus-gateway not found: set %s or --klaus-gateway-bin, or install klaus-gateway on PATH (container mode is not yet available in this release)", klausGatewayBinEnv)
+	}
+
+	logLevel := opts.LogLevel
+	if logLevel == "" {
+		logLevel = cfg.LogLevel
+	}
+	if logLevel == "" {
+		logLevel = "info"
+	}
+
+	selfBin, err := os.Executable()
+	if err != nil {
+		// Fall back to the command name if the executable path is unavailable
+		// (e.g. in a static go test binary). klaus-gateway will still be able
+		// to find klausctl on PATH in most dev environments.
+		selfBin = "klausctl"
+	}
+
+	args := []string{
+		fmt.Sprintf("--listen-address=:%d", port),
+		fmt.Sprintf("--admin-address=:%d", port+1),
+		"--store=bolt",
+		"--bolt-path", paths.GatewayRoutesBoltFile,
+		"--driver=klausctl",
+		"--klausctl-bin", selfBin,
+		fmt.Sprintf("--log-level=%s", logLevel),
+	}
+	if agentGatewayURL != "" {
+		args = append(args, fmt.Sprintf("--agentgateway-url=%s", agentGatewayURL))
+	}
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	setSysProcAttr(cmd)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting klaus-gateway: %w", err)
+	}
+
+	pid := cmd.Process.Pid
+	if err := writePID(paths.KlausGatewayPIDFile, pid); err != nil {
+		return nil, fmt.Errorf("writing klaus-gateway PID file: %w", err)
+	}
+	if err := writePort(paths.KlausGatewayPortFile, port); err != nil {
+		return nil, fmt.Errorf("writing klaus-gateway port file: %w", err)
+	}
+	if err := writeMode(paths.KlausGatewayPIDFile, mode); err != nil {
+		return nil, fmt.Errorf("writing klaus-gateway mode file: %w", err)
+	}
+
+	if err := cmd.Process.Release(); err != nil {
+		return nil, fmt.Errorf("releasing klaus-gateway process: %w", err)
+	}
+
+	if err := waitHealthy(ctx, port); err != nil {
+		return nil, fmt.Errorf("klaus-gateway started (PID %d) but did not become healthy: %w", pid, err)
+	}
+
+	return &Status{
+		Running: true,
+		PID:     pid,
+		Port:    port,
+		URL:     bridgeURL(port),
+		Healthy: true,
+		Mode:    mode,
+	}, nil
+}
+
+// stopKlausGateway terminates the klaus-gateway process and removes its
+// PID/port files. Returns nil when no PID file is present (idempotent).
+func stopKlausGateway(paths *config.Paths) error {
+	pid, err := readPID(paths.KlausGatewayPIDFile)
+	if err != nil {
+		return nil
+	}
+	if err := stopProcess(pid); err != nil {
+		return fmt.Errorf("stopping klaus-gateway: %w", err)
+	}
+	cleanupKlausGatewayFiles(paths)
+	return nil
+}
+
+// firstNonZero returns the first non-zero int from the argument list, or zero
+// if they are all zero.
+func firstNonZero(vs ...int) int {
+	for _, v := range vs {
+		if v != 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+// modePath returns the path where the start mode ("host" or "container") is
+// persisted alongside the PID file.
+func modePath(pidFile string) string {
+	return strings.TrimSuffix(pidFile, ".pid") + ".mode"
+}
+
+func writeMode(pidFile, mode string) error {
+	return os.WriteFile(modePath(pidFile), []byte(mode), 0o644)
+}
+
+func modeLabel(pidFile string) string {
+	data, err := os.ReadFile(modePath(pidFile))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/pkg/gatewaybridge/health.go
+++ b/pkg/gatewaybridge/health.go
@@ -1,0 +1,52 @@
+package gatewaybridge
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	healthPollTimeout = 15 * time.Second
+	healthPollDelay   = 500 * time.Millisecond
+)
+
+// waitHealthy polls http://localhost:<port>/healthz until it returns a non-5xx
+// response or the timeout is reached.
+func waitHealthy(ctx context.Context, port int) error {
+	deadline := time.Now().Add(healthPollTimeout)
+	url := fmt.Sprintf("http://localhost:%d/healthz", port)
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		resp, err := client.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode < 500 {
+				return nil
+			}
+		}
+
+		time.Sleep(healthPollDelay)
+	}
+
+	return fmt.Errorf("timed out waiting for /healthz on port %d", port)
+}
+
+// healthyNow reports whether /healthz responds non-5xx within a short timeout.
+func healthyNow(port int) bool {
+	client := &http.Client{Timeout: 1 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/healthz", port))
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode < 500
+}

--- a/pkg/gatewaybridge/ports.go
+++ b/pkg/gatewaybridge/ports.go
@@ -1,0 +1,31 @@
+package gatewaybridge
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+func readPID(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(data)))
+}
+
+func readPort(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(data)))
+}
+
+func writePID(path string, pid int) error {
+	return os.WriteFile(path, []byte(strconv.Itoa(pid)), 0o644)
+}
+
+func writePort(path string, port int) error {
+	return os.WriteFile(path, []byte(strconv.Itoa(port)), 0o644)
+}

--- a/pkg/gatewaybridge/proc_unix.go
+++ b/pkg/gatewaybridge/proc_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package gatewaybridge
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func sendTermSignal(proc *os.Process) error {
+	return proc.Signal(syscall.SIGTERM)
+}
+
+func sendKillSignal(proc *os.Process) error {
+	return proc.Signal(syscall.SIGKILL)
+}
+
+func processAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/pkg/gatewaybridge/proc_windows.go
+++ b/pkg/gatewaybridge/proc_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package gatewaybridge
+
+import (
+	"os"
+	"os/exec"
+)
+
+func setSysProcAttr(_ *exec.Cmd) {}
+
+func sendTermSignal(proc *os.Process) error {
+	return proc.Kill()
+}
+
+func sendKillSignal(proc *os.Process) error {
+	return proc.Kill()
+}
+
+func processAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(os.Signal(nil))
+	return err == nil
+}


### PR DESCRIPTION
## Summary

Adds a local lifecycle manager for `klaus-gateway` (and optionally the upstream `agentgateway`) that mirrors the shape of `pkg/musterbridge`. The bridge spawns the process, tracks PID/port, health-checks `/healthz`, and auto-registers the MCP HTTP endpoint in `~/.config/klausctl/mcpservers.yaml` so containerized klaus instances can reach it via `host.docker.internal`.

Closes #195.

### Surfaces

- **CLI**: `klausctl gateway start|stop|status` with flags for `--with-agentgateway`, `--port`, `--agentgateway-port`, `--klaus-gateway-bin`, `--agentgateway-bin`, `--log-level`.
- **MCP tools**: `klaus_gateway_start`, `klaus_gateway_stop`, `klaus_gateway_status` — registered in `klausctl serve`.
- **Auto-start hook**: `klausctl start` calls `gatewaybridge.EnsureRunning(...)` and appends `klaus-gateway` to `mcpServerRefs` when the instance config declares `requires.gateway.enabled: true`.

### Acceptance criteria coverage

- ✅ Public surface matches `pkg/musterbridge`: `Start`, `Stop`, `GetStatus`, `EnsureRunning`, `Restart`.
- ✅ State directory layout with strict ownership boundaries, enforced by `TestOwnership` in `pkg/gatewaybridge`.
- ✅ `klausctl`-owned: `klaus-gateway.{pid,port}`, `agentgateway.{pid,port}`, `gateway/routes.bolt`. User-owned: `gateway/config.yaml`, `gateway/slack-secrets.yaml`.
- ✅ CLI/MCP parity: `cmd/gateway_parity_test.go` inspects both surfaces dynamically (CLI via `pflag.FlagSet.VisitAll`, MCP via `tool.InputSchema.Properties`) and asserts bidirectional set equality. Both surfaces are driven by a single source of truth in `internal/gatewaysurface`.
- ✅ Runtime selection: `--klaus-gateway-bin` > `KLAUS_GATEWAY_BIN` > `PATH`; same precedence for agentgateway.
- ✅ Stale PID detection in `GetStatus` and `Start` — falls through to a clean restart rather than failing.
- ✅ Docs added in `docs/gatewaybridge.md`.

### Files

- `pkg/gatewaybridge/` — new package (bridge.go, config.go, gateway.go, agentgateway.go, health.go, ports.go, proc_unix.go, proc_windows.go, bridge_test.go)
- `internal/gatewaysurface/surface.go` — shared CLI/MCP flag spec (avoids cmd ↔ internal/tools/gateway import cycle)
- `internal/tools/gateway/tools.go` — MCP tool registration
- `cmd/gateway.go`, `cmd/gateway_parity_test.go` — CLI + parity test
- `cmd/serve.go` — register gateway MCP tools
- `cmd/start.go`, `pkg/config/config.go` — auto-start hook + `requires.gateway` config field
- `pkg/config/paths.go` — gateway-related paths
- `docs/gatewaybridge.md` — user-facing docs

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test ./cmd/... ./pkg/gatewaybridge/... ./pkg/config/... ./pkg/musterbridge/...` — all green locally
- [ ] CI green on PR
- [ ] Manual smoke test once `klaus-gateway` binary is available (deferred — binary not yet released, but `--klaus-gateway-bin` escape hatch + `KLAUS_GATEWAY_BIN` env var make it trivial to exercise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)