### PR TITLE
feat: add --remote targeting for run/prompt/messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ klausctl logs default -f
 klausctl stop default
 ```
 
+To target a remote [klaus-gateway](https://github.com/giantswarm/klaus-gateway)
+instead of a local container, authenticate once and then pass `--remote=URL`
+to `run`, `prompt`, or `messages`. See [docs/remote.md](docs/remote.md) for
+details.
+
+```bash
+klausctl auth login --remote=https://gw.example.com
+klausctl run my-bot --remote=https://gw.example.com -m "summarise the week"
+```
+
 ## Usage
 
 ```

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/remote"
+)
+
+var (
+	authLoginRemote string
+	authLogoutRemote string
+)
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Authenticate with remote klaus-gateway endpoints",
+	Long: `Manage OAuth credentials for remote klaus-gateway endpoints used by
+'klausctl run/prompt/messages --remote=URL'.
+
+Credentials are stored under ~/.config/klausctl/auth/<host>.yaml with file
+mode 0600 and refreshed automatically on 401 responses.`,
+}
+
+var authLoginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Log in to a remote klaus-gateway via OAuth",
+	Long: `Perform browser-based OAuth login for the given klaus-gateway URL.
+
+The gateway is probed for OAuth metadata, a browser window is opened for
+authentication, and the resulting credentials are persisted locally.
+
+  klausctl auth login --remote=https://gw.example.com`,
+	Args: cobra.NoArgs,
+	RunE: runAuthLogin,
+}
+
+var authLogoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Remove stored credentials for a remote klaus-gateway",
+	Args:  cobra.NoArgs,
+	RunE:  runAuthLogout,
+}
+
+var authStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show authentication status for remote klaus-gateway endpoints",
+	Args:  cobra.NoArgs,
+	RunE:  runAuthStatus,
+}
+
+func init() {
+	authLoginCmd.Flags().StringVar(&authLoginRemote, "remote", "", "remote klaus-gateway URL (required)")
+	_ = authLoginCmd.MarkFlagRequired("remote")
+
+	authLogoutCmd.Flags().StringVar(&authLogoutRemote, "remote", "", "remote klaus-gateway URL (required)")
+	_ = authLogoutCmd.MarkFlagRequired("remote")
+
+	authCmd.AddCommand(authLoginCmd)
+	authCmd.AddCommand(authLogoutCmd)
+	authCmd.AddCommand(authStatusCmd)
+	rootCmd.AddCommand(authCmd)
+}
+
+func runAuthLogin(cmd *cobra.Command, _ []string) error {
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+
+	store := remote.NewAuthStore(paths.AuthDir)
+	rec, err := remote.Login(cmd.Context(), store, authLoginRemote, remote.LoginOptions{})
+	if err != nil {
+		return fmt.Errorf("login failed for %s: %w", authLoginRemote, err)
+	}
+
+	out := cmd.OutOrStdout()
+	if !rec.ExpiresAt.IsZero() {
+		fmt.Fprintf(out, "Login successful for %s. Token expires at %s.\n", rec.ServerURL, rec.ExpiresAt.Format(time.RFC3339))
+	} else {
+		fmt.Fprintf(out, "Login successful for %s.\n", rec.ServerURL)
+	}
+	return nil
+}
+
+func runAuthLogout(cmd *cobra.Command, _ []string) error {
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+
+	normURL, err := remote.NormalizeBaseURL(authLogoutRemote)
+	if err != nil {
+		return err
+	}
+
+	store := remote.NewAuthStore(paths.AuthDir)
+	if err := store.Delete(normURL); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Logged out from %s.\n", normURL)
+	return nil
+}
+
+func runAuthStatus(cmd *cobra.Command, _ []string) error {
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+
+	store := remote.NewAuthStore(paths.AuthDir)
+	records, err := store.List()
+	if err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	if len(records) == 0 {
+		fmt.Fprintln(out, "No remote klaus-gateway credentials stored.")
+		return nil
+	}
+
+	for _, rec := range records {
+		state := "valid"
+		if rec.IsExpired(0) {
+			state = "expired"
+		}
+		fmt.Fprintf(out, "%s  [%s]", rec.ServerURL, state)
+		if !rec.ExpiresAt.IsZero() {
+			fmt.Fprintf(out, "  expires=%s", rec.ExpiresAt.Format(time.RFC3339))
+		}
+		fmt.Fprintln(out)
+	}
+	return nil
+}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	authLoginRemote string
+	authLoginRemote  string
 	authLogoutRemote string
 )
 

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -22,6 +22,9 @@ import (
 var (
 	messagesFollow bool
 	messagesOutput string
+
+	messagesRemote  string
+	messagesSession string
 )
 
 var messagesCmd = &cobra.Command{
@@ -43,6 +46,10 @@ Examples:
 func init() {
 	messagesCmd.Flags().BoolVarP(&messagesFollow, "follow", "f", false, "follow new messages in real time")
 	messagesCmd.Flags().StringVarP(&messagesOutput, "output", "o", "text", "output format: text, json")
+
+	messagesCmd.Flags().StringVar(&messagesRemote, remoteFlagName("remote"), "", remoteFlagDesc("remote"))
+	messagesCmd.Flags().StringVar(&messagesSession, remoteFlagName("session"), "", remoteFlagDesc("session"))
+
 	rootCmd.AddCommand(messagesCmd)
 }
 
@@ -92,6 +99,11 @@ func runMessages(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if messagesRemote != "" {
+		return runMessagesRemote(ctx, out, paths, instanceName)
+	}
+
 	paths = paths.ForInstance(instanceName)
 
 	inst, err := instance.Load(paths)
@@ -121,6 +133,29 @@ func runMessages(cmd *cobra.Command, args []string) error {
 		return fetchAndRenderMessages(ctx, out, client, instanceName, baseURL)
 	}
 
+	return followMessages(ctx, out, client, instanceName, baseURL)
+}
+
+// runMessagesRemote fetches conversation messages from a remote gateway,
+// bypassing local runtime state entirely.
+func runMessagesRemote(ctx context.Context, out io.Writer, paths *config.Paths, instanceName string) error {
+	target, _, _, err := resolveRemoteTarget(ctx, messagesRemote, instanceName, messagesSession, paths)
+	if err != nil {
+		return err
+	}
+
+	headers := target.Headers()
+	if target.BearerToken != "" {
+		headers["Authorization"] = "Bearer " + target.BearerToken
+	}
+
+	client := mcpclient.NewWithHeaders(buildVersion, headers)
+	defer client.Close()
+
+	baseURL := target.MCPURL()
+	if !messagesFollow {
+		return fetchAndRenderMessages(ctx, out, client, instanceName, baseURL)
+	}
 	return followMessages(ctx, out, client, instanceName, baseURL)
 }
 

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -21,6 +21,9 @@ var (
 	promptMessage  string
 	promptBlocking bool
 	promptOutput   string
+
+	promptRemote  string
+	promptSession string
 )
 
 var promptCmd = &cobra.Command{
@@ -44,6 +47,10 @@ func init() {
 	promptCmd.Flags().StringVarP(&promptMessage, "message", "m", "", "prompt message to send to the agent (required)")
 	promptCmd.Flags().BoolVar(&promptBlocking, "blocking", false, "wait for the agent to complete and return the result")
 	promptCmd.Flags().StringVarP(&promptOutput, "output", "o", "text", "output format: text, json")
+
+	promptCmd.Flags().StringVar(&promptRemote, remoteFlagName("remote"), "", remoteFlagDesc("remote"))
+	promptCmd.Flags().StringVar(&promptSession, remoteFlagName("session"), "", remoteFlagDesc("session"))
+
 	_ = promptCmd.MarkFlagRequired("message")
 	rootCmd.AddCommand(promptCmd)
 }
@@ -72,6 +79,11 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if promptRemote != "" {
+		return runPromptRemote(ctx, out, paths, instanceName)
+	}
+
 	paths = paths.ForInstance(instanceName)
 
 	inst, err := instance.Load(paths)
@@ -105,7 +117,10 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 // runPromptBlocking sends the prompt via the chat completions streaming API
 // and prints content deltas as they arrive.
 func runPromptBlocking(ctx context.Context, out io.Writer, httpClient *http.Client, agentURL, instanceName string) error {
-	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentURL, promptMessage)
+	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentclient.CompletionRequest{
+		URL:    agentURL + "/v1/chat/completions",
+		Prompt: promptMessage,
+	})
 	if err != nil {
 		return fmt.Errorf("sending prompt to %q: %w", instanceName, err)
 	}
@@ -127,7 +142,10 @@ func runPromptBlocking(ctx context.Context, out io.Writer, httpClient *http.Clie
 // runPromptNonBlocking sends the prompt via the completions API and returns
 // immediately.
 func runPromptNonBlocking(ctx context.Context, out io.Writer, httpClient *http.Client, agentURL, instanceName string) error {
-	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentURL, promptMessage)
+	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentclient.CompletionRequest{
+		URL:    agentURL + "/v1/chat/completions",
+		Prompt: promptMessage,
+	})
 	if err != nil {
 		return fmt.Errorf("sending prompt to %q: %w", instanceName, err)
 	}
@@ -141,6 +159,45 @@ func runPromptNonBlocking(ctx context.Context, out io.Writer, httpClient *http.C
 		Status:   "started",
 	}
 	return renderPromptResult(out, result)
+}
+
+// runPromptRemote sends a prompt to a remote klaus-gateway endpoint
+// without consulting the local runtime or instance state.
+func runPromptRemote(ctx context.Context, out io.Writer, paths *config.Paths, instanceName string) error {
+	target, store, rec, err := resolveRemoteTarget(ctx, promptRemote, instanceName, promptSession, paths)
+	if err != nil {
+		return err
+	}
+
+	httpClient := &http.Client{}
+	compCh, err := streamRemoteCompletion(ctx, httpClient, &target, store, rec, promptMessage)
+	if err != nil {
+		return fmt.Errorf("sending prompt to %q: %w", instanceName, err)
+	}
+
+	if !promptBlocking {
+		go func() {
+			for range compCh {
+			}
+		}()
+		return renderPromptResult(out, promptCLIResult{
+			Instance: instanceName,
+			Status:   "started",
+		})
+	}
+
+	for delta := range compCh {
+		if delta.Err != nil {
+			return fmt.Errorf("streaming from %q: %w", instanceName, delta.Err)
+		}
+		fmt.Fprint(out, delta.Content)
+	}
+	fmt.Fprintln(out)
+
+	return renderPromptResult(out, promptCLIResult{
+		Instance: instanceName,
+		Status:   "completed",
+	})
 }
 
 func renderPromptResult(out io.Writer, result promptCLIResult) error {

--- a/cmd/remote_helpers.go
+++ b/cmd/remote_helpers.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/giantswarm/klausctl/internal/remotesurface"
+	"github.com/giantswarm/klausctl/pkg/agentclient"
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/remote"
+)
+
+// remoteFlagName returns the canonical CLI flag name for a key declared
+// in remotesurface.Flags; panics on an unknown key so misspellings fail
+// at init time. Used by all subcommands wiring --remote/--session.
+func remoteFlagName(key string) string {
+	return remotesurface.CLIFlagByKey(key).CLIFlag
+}
+
+// remoteFlagDesc returns the description for a remotesurface.Flag key;
+// panics on an unknown key.
+func remoteFlagDesc(key string) string {
+	return remotesurface.CLIFlagByKey(key).Description
+}
+
+// tokenRefreshLeeway gives refresh a head start: records expiring in the
+// next 60s are refreshed proactively before making a call.
+const tokenRefreshLeeway = 60 * time.Second
+
+// resolveRemoteTarget composes a remote.Target for the given URL + instance.
+// It loads any cached auth record and, when present, refreshes it if it
+// is within the tokenRefreshLeeway. Absence of an auth record is not an
+// error — some klaus-gateway deployments run without OAuth.
+func resolveRemoteTarget(ctx context.Context, remoteURL, instance, session string, paths *config.Paths) (remote.Target, *remote.AuthStore, *remote.AuthRecord, error) {
+	normURL, err := remote.NormalizeBaseURL(remoteURL)
+	if err != nil {
+		return remote.Target{}, nil, nil, err
+	}
+
+	store := remote.NewAuthStore(paths.AuthDir)
+	rec, err := store.Get(normURL)
+	if err != nil {
+		return remote.Target{}, nil, nil, fmt.Errorf("reading auth record for %s: %w", normURL, err)
+	}
+
+	var bearer string
+	if rec != nil {
+		if rec.IsExpired(tokenRefreshLeeway) {
+			refreshed, refreshErr := remote.Refresh(ctx, http.DefaultClient, *rec)
+			if refreshErr != nil {
+				var reloginErr *remote.ErrReloginRequired
+				if errors.As(refreshErr, &reloginErr) {
+					return remote.Target{}, nil, nil, fmt.Errorf("stored credentials for %s are no longer valid; re-run 'klausctl auth login --remote=%s'", normURL, normURL)
+				}
+				return remote.Target{}, nil, nil, fmt.Errorf("refreshing token for %s: %w", normURL, refreshErr)
+			}
+			if err := store.Put(refreshed); err != nil {
+				return remote.Target{}, nil, nil, fmt.Errorf("persisting refreshed token: %w", err)
+			}
+			rec = &refreshed
+		}
+		bearer = rec.AccessToken
+	}
+
+	target, err := remote.NewTarget(normURL, instance, session, bearer)
+	if err != nil {
+		return remote.Target{}, nil, nil, err
+	}
+	return target, store, rec, nil
+}
+
+// streamRemoteCompletion sends a prompt to a remote gateway, retrying
+// exactly once on HTTP 401 by refreshing the cached token. Returns the
+// (already-started) delta channel.
+func streamRemoteCompletion(ctx context.Context, httpClient *http.Client, target *remote.Target, store *remote.AuthStore, rec *remote.AuthRecord, prompt string) (<-chan agentclient.CompletionDelta, error) {
+	req := agentclient.CompletionRequest{
+		URL:     target.CompletionsURL(),
+		Prompt:  prompt,
+		Bearer:  target.BearerToken,
+		Headers: target.Headers(),
+	}
+
+	ch, err := agentclient.StreamCompletion(ctx, httpClient, req)
+	if err == nil {
+		return ch, nil
+	}
+
+	var httpErr *agentclient.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusUnauthorized || rec == nil {
+		return nil, err
+	}
+
+	// One-shot refresh + retry.
+	refreshed, refreshErr := remote.Refresh(ctx, http.DefaultClient, *rec)
+	if refreshErr != nil {
+		var reloginErr *remote.ErrReloginRequired
+		if errors.As(refreshErr, &reloginErr) {
+			return nil, fmt.Errorf("remote %s rejected credentials; re-run 'klausctl auth login --remote=%s'", target.BaseURL, target.BaseURL)
+		}
+		return nil, fmt.Errorf("refreshing token after 401: %w", refreshErr)
+	}
+	if err := store.Put(refreshed); err != nil {
+		return nil, fmt.Errorf("persisting refreshed token: %w", err)
+	}
+
+	target.BearerToken = refreshed.AccessToken
+	req.Bearer = refreshed.AccessToken
+	return agentclient.StreamCompletion(ctx, httpClient, req)
+}

--- a/cmd/remote_integration_test.go
+++ b/cmd/remote_integration_test.go
@@ -1,0 +1,274 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/remote"
+)
+
+// gatewayRequest captures the request context we want to assert on.
+type gatewayRequest struct {
+	Method string
+	Path   string
+	Auth   string
+	Header http.Header
+	Body   string
+}
+
+// fakeGateway mimics a klaus-gateway /v1/{instance}/chat/completions
+// endpoint. It echoes streamed content chunks back to the caller and
+// records every incoming request for assertions.
+func fakeGateway(t *testing.T, firstStatus int) (*httptest.Server, *[]gatewayRequest) {
+	t.Helper()
+	var requests []gatewayRequest
+	var calls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests = append(requests, gatewayRequest{
+			Method: r.Method,
+			Path:   r.URL.Path,
+			Auth:   r.Header.Get("Authorization"),
+			Header: r.Header.Clone(),
+			Body:   string(body),
+		})
+		n := calls.Add(1)
+
+		if n == 1 && firstStatus != http.StatusOK {
+			w.WriteHeader(firstStatus)
+			_, _ = fmt.Fprintln(w, `{"error":"unauthorized"}`)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		chunks := []string{"Hello", ", ", "world!"}
+		for _, c := range chunks {
+			payload := map[string]any{
+				"choices": []map[string]any{{"delta": map[string]string{"content": c}}},
+			}
+			b, _ := json.Marshal(payload)
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", b)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	return srv, &requests
+}
+
+// fakeTokenEndpoint returns an OAuth token endpoint that issues the given
+// access token on every refresh call.
+func fakeTokenEndpoint(t *testing.T, newAccess, newRefresh string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  newAccess,
+			"token_type":    "Bearer",
+			"refresh_token": newRefresh,
+			"expires_in":    3600,
+		})
+	}))
+}
+
+func TestStreamRemoteCompletionEndToEnd(t *testing.T) {
+	gw, requests := fakeGateway(t, http.StatusOK)
+	defer gw.Close()
+
+	paths := &config.Paths{AuthDir: filepath.Join(t.TempDir(), "auth")}
+	store := remote.NewAuthStore(paths.AuthDir)
+	rec := remote.AuthRecord{
+		ServerURL:    gw.URL,
+		AccessToken:  "tok-1",
+		RefreshToken: "rt-1",
+		ExpiresAt:    time.Now().Add(30 * time.Minute),
+	}
+	if err := store.Put(rec); err != nil {
+		t.Fatalf("store.Put: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	target, resStore, resRec, err := resolveRemoteTarget(ctx, gw.URL, "dev", "sess-1", paths)
+	if err != nil {
+		t.Fatalf("resolveRemoteTarget: %v", err)
+	}
+
+	ch, err := streamRemoteCompletion(ctx, gw.Client(), &target, resStore, resRec, "hello")
+	if err != nil {
+		t.Fatalf("streamRemoteCompletion: %v", err)
+	}
+	var got strings.Builder
+	for d := range ch {
+		if d.Err != nil {
+			t.Fatalf("delta err: %v", d.Err)
+		}
+		got.WriteString(d.Content)
+	}
+	if got.String() != "Hello, world!" {
+		t.Errorf("stream content = %q, want %q", got.String(), "Hello, world!")
+	}
+
+	if len(*requests) != 1 {
+		t.Fatalf("expected 1 gateway request, got %d", len(*requests))
+	}
+	r := (*requests)[0]
+	if r.Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", r.Method)
+	}
+	if r.Path != "/v1/dev/chat/completions" {
+		t.Errorf("path = %q, want /v1/dev/chat/completions", r.Path)
+	}
+	if r.Auth != "Bearer tok-1" {
+		t.Errorf("Authorization = %q, want Bearer tok-1", r.Auth)
+	}
+	if got := r.Header.Get(remote.ChannelHeader); got != remote.ChannelCLI {
+		t.Errorf("%s = %q, want %q", remote.ChannelHeader, got, remote.ChannelCLI)
+	}
+	if got := r.Header.Get(remote.ThreadIDHeader); got != "sess-1" {
+		t.Errorf("%s = %q, want sess-1", remote.ThreadIDHeader, got)
+	}
+	if r.Header.Get(remote.ChannelIDHeader) == "" {
+		t.Errorf("%s should be populated", remote.ChannelIDHeader)
+	}
+	if !strings.Contains(r.Body, `"stream":true`) {
+		t.Errorf("body missing stream:true: %s", r.Body)
+	}
+	if !strings.Contains(r.Body, `"content":"hello"`) {
+		t.Errorf("body missing user prompt: %s", r.Body)
+	}
+}
+
+func TestStreamRemoteCompletionRefreshesOn401(t *testing.T) {
+	gw, requests := fakeGateway(t, http.StatusUnauthorized)
+	defer gw.Close()
+
+	tokenSrv := fakeTokenEndpoint(t, "new-access-token", "new-refresh-token")
+	defer tokenSrv.Close()
+
+	paths := &config.Paths{AuthDir: filepath.Join(t.TempDir(), "auth")}
+	store := remote.NewAuthStore(paths.AuthDir)
+	rec := remote.AuthRecord{
+		ServerURL:     gw.URL,
+		AccessToken:   "stale-token",
+		RefreshToken:  "rt-1",
+		TokenEndpoint: tokenSrv.URL,
+		ExpiresAt:     time.Now().Add(30 * time.Minute),
+	}
+	if err := store.Put(rec); err != nil {
+		t.Fatalf("store.Put: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	target, resStore, resRec, err := resolveRemoteTarget(ctx, gw.URL, "dev", "sess-retry", paths)
+	if err != nil {
+		t.Fatalf("resolveRemoteTarget: %v", err)
+	}
+
+	ch, err := streamRemoteCompletion(ctx, gw.Client(), &target, resStore, resRec, "hello")
+	if err != nil {
+		t.Fatalf("streamRemoteCompletion: %v", err)
+	}
+	var got strings.Builder
+	for d := range ch {
+		if d.Err != nil {
+			t.Fatalf("delta err: %v", d.Err)
+		}
+		got.WriteString(d.Content)
+	}
+	if got.String() != "Hello, world!" {
+		t.Errorf("content after refresh = %q, want Hello, world!", got.String())
+	}
+
+	if len(*requests) != 2 {
+		t.Fatalf("expected 2 gateway requests (401 + retry), got %d", len(*requests))
+	}
+	if (*requests)[0].Auth != "Bearer stale-token" {
+		t.Errorf("first request auth = %q, want stale-token", (*requests)[0].Auth)
+	}
+	if (*requests)[1].Auth != "Bearer new-access-token" {
+		t.Errorf("retry auth = %q, want new-access-token", (*requests)[1].Auth)
+	}
+
+	// Refreshed token must have been persisted.
+	persisted, err := store.Get(gw.URL)
+	if err != nil {
+		t.Fatalf("store.Get after refresh: %v", err)
+	}
+	if persisted == nil || persisted.AccessToken != "new-access-token" || persisted.RefreshToken != "new-refresh-token" {
+		t.Errorf("refreshed token not persisted: %+v", persisted)
+	}
+}
+
+func TestResolveRemoteTargetProactiveRefresh(t *testing.T) {
+	tokenSrv := fakeTokenEndpoint(t, "rotated-token", "rotated-refresh")
+	defer tokenSrv.Close()
+
+	paths := &config.Paths{AuthDir: filepath.Join(t.TempDir(), "auth")}
+	store := remote.NewAuthStore(paths.AuthDir)
+	expired := remote.AuthRecord{
+		ServerURL:     "https://gw.example.com",
+		AccessToken:   "about-to-expire",
+		RefreshToken:  "rt-1",
+		TokenEndpoint: tokenSrv.URL,
+		ExpiresAt:     time.Now().Add(5 * time.Second), // within 60s leeway
+	}
+	if err := store.Put(expired); err != nil {
+		t.Fatalf("store.Put: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	target, _, rec, err := resolveRemoteTarget(ctx, "https://gw.example.com", "dev", "", paths)
+	if err != nil {
+		t.Fatalf("resolveRemoteTarget: %v", err)
+	}
+	if target.BearerToken != "rotated-token" {
+		t.Errorf("target bearer = %q, want rotated-token", target.BearerToken)
+	}
+	if rec == nil || rec.AccessToken != "rotated-token" {
+		t.Errorf("returned rec not refreshed: %+v", rec)
+	}
+
+	persisted, err := store.Get("https://gw.example.com")
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if persisted == nil || persisted.AccessToken != "rotated-token" {
+		t.Errorf("proactive refresh not persisted: %+v", persisted)
+	}
+}
+
+func TestResolveRemoteTargetNoAuthRecord(t *testing.T) {
+	paths := &config.Paths{AuthDir: filepath.Join(t.TempDir(), "auth")}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	target, _, rec, err := resolveRemoteTarget(ctx, "https://gw.example.com", "dev", "", paths)
+	if err != nil {
+		t.Fatalf("resolveRemoteTarget without stored auth: %v", err)
+	}
+	if target.BearerToken != "" {
+		t.Errorf("expected empty bearer when no auth record, got %q", target.BearerToken)
+	}
+	if rec != nil {
+		t.Errorf("expected nil auth record, got %+v", rec)
+	}
+}

--- a/cmd/remote_parity_test.go
+++ b/cmd/remote_parity_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/giantswarm/klausctl/internal/remotesurface"
+	internalserver "github.com/giantswarm/klausctl/internal/server"
+	instancetools "github.com/giantswarm/klausctl/internal/tools/instance"
+	"github.com/giantswarm/klausctl/pkg/config"
+)
+
+// TestRemoteSurfaceFlagParity asserts that the `remote` and `session` inputs
+// declared in internal/remotesurface are wired identically to every CLI
+// subcommand (run/prompt/messages) and every matching MCP tool (klaus_run,
+// klaus_prompt, klaus_messages). This is the acceptance criterion extending
+// PR #196's gateway parity check to the new remote-targeting surface.
+func TestRemoteSurfaceFlagParity(t *testing.T) {
+	surfaceCLI := remoteCLINames()
+	surfaceMCP := remoteMCPNames()
+
+	if len(surfaceCLI) != len(surfaceMCP) {
+		t.Fatalf("remotesurface.Flags: CLI names (%d) differ from MCP keys (%d)", len(surfaceCLI), len(surfaceMCP))
+	}
+
+	instanceSrv := newInstanceToolsServer(t)
+
+	cases := []struct {
+		label    string
+		cliFlags map[string]struct{}
+		mcpProps map[string]struct{}
+	}{
+		{
+			label:    "run / klaus_run",
+			cliFlags: collectCLIFlagNames(runCmd.Flags()),
+			mcpProps: mcpToolProperties(t, instanceSrv, "klaus_run"),
+		},
+		{
+			label:    "prompt / klaus_prompt",
+			cliFlags: collectCLIFlagNames(promptCmd.Flags()),
+			mcpProps: mcpToolProperties(t, instanceSrv, "klaus_prompt"),
+		},
+		{
+			label:    "messages / klaus_messages",
+			cliFlags: collectCLIFlagNames(messagesCmd.Flags()),
+			mcpProps: mcpToolProperties(t, instanceSrv, "klaus_messages"),
+		},
+	}
+
+	for _, c := range cases {
+		assertSubset(t, "CLI flags on `klausctl "+c.label+"`", surfaceCLI, c.cliFlags)
+		assertSubset(t, "MCP inputs on "+c.label, surfaceMCP, c.mcpProps)
+	}
+}
+
+// TestRemoteSurfaceFlagsPresent guarantees the shared surface package itself
+// still declares exactly `remote` and `session`. Adding or removing an entry
+// here must be paired with updated CLI bindings and MCP registrations.
+func TestRemoteSurfaceFlagsPresent(t *testing.T) {
+	want := map[string]struct{}{"remote": {}, "session": {}}
+	assertSetEqual(t, "remotesurface.Flags CLI names", remoteCLINames(), want)
+	assertSetEqual(t, "remotesurface.Flags MCP keys", remoteMCPNames(), want)
+}
+
+func remoteCLINames() map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, f := range remotesurface.Flags {
+		out[f.CLIFlag] = struct{}{}
+	}
+	return out
+}
+
+func remoteMCPNames() map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, f := range remotesurface.Flags {
+		out[f.MCPKey] = struct{}{}
+	}
+	return out
+}
+
+// newInstanceToolsServer builds a fresh MCP server with instance tools
+// registered against it. The backing ServerContext uses ephemeral paths so
+// nothing on the host filesystem is touched.
+func newInstanceToolsServer(t *testing.T) *server.MCPServer {
+	t.Helper()
+	srv := server.NewMCPServer("klausctl-test", "test")
+	sc := &internalserver.ServerContext{
+		Paths: &config.Paths{
+			ConfigDir: t.TempDir(),
+		},
+	}
+	instancetools.RegisterTools(srv, sc)
+	return srv
+}
+
+// mcpToolProperties returns the set of input property names registered on
+// the named MCP tool against an already-built server.
+func mcpToolProperties(t *testing.T, srv *server.MCPServer, toolName string) map[string]struct{} {
+	t.Helper()
+	tools := srv.ListTools()
+	tool, ok := tools[toolName]
+	if !ok {
+		t.Fatalf("MCP tool %q is not registered; available tools: %v", toolName, toolNames(tools))
+	}
+	props := map[string]struct{}{}
+	for k := range tool.Tool.InputSchema.Properties {
+		props[k] = struct{}{}
+	}
+	return props
+}
+
+// assertSubset verifies every key in `want` is present in `got`. Unlike
+// assertSetEqual, extra entries in `got` are permitted (e.g. run/prompt/
+// messages carry many flags beyond the shared remote surface).
+func assertSubset(t *testing.T, label string, want, got map[string]struct{}) {
+	t.Helper()
+	missing := difference(want, got)
+	if len(missing) == 0 {
+		return
+	}
+	sort.Strings(missing)
+	t.Errorf("%s missing expected entries: %v", label, missing)
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -44,6 +44,9 @@ var (
 	runMessage  string
 	runBlocking bool
 	runOutput   string
+
+	runRemote  string
+	runSession string
 )
 
 var runCmd = &cobra.Command{
@@ -96,6 +99,10 @@ func init() {
 	runCmd.Flags().StringVarP(&runMessage, "message", "m", "", "prompt message to send to the agent (required)")
 	runCmd.Flags().BoolVar(&runBlocking, "blocking", false, "wait for the agent to complete and return the result")
 	runCmd.Flags().StringVarP(&runOutput, "output", "o", "text", "output format: text, json")
+
+	runCmd.Flags().StringVar(&runRemote, remoteFlagName("remote"), "", remoteFlagDesc("remote"))
+	runCmd.Flags().StringVar(&runSession, remoteFlagName("session"), "", remoteFlagDesc("session"))
+
 	_ = runCmd.MarkFlagRequired("message")
 	rootCmd.AddCommand(runCmd)
 }
@@ -103,6 +110,10 @@ func init() {
 func runRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
+
+	if runRemote != "" {
+		return runRunRemote(ctx, cmd, args)
+	}
 
 	workspace := ""
 	if len(args) > 1 {
@@ -175,7 +186,10 @@ func runRun(cmd *cobra.Command, args []string) error {
 // runBlocked sends the prompt via the chat completions streaming API and
 // prints content deltas as they arrive.
 func runBlocked(ctx context.Context, out io.Writer, httpClient *http.Client, agentURL, instanceName string) error {
-	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentURL, runMessage)
+	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentclient.CompletionRequest{
+		URL:    agentURL + "/v1/chat/completions",
+		Prompt: runMessage,
+	})
 	if err != nil {
 		return fmt.Errorf("sending prompt to %q: %w", instanceName, err)
 	}
@@ -197,7 +211,10 @@ func runBlocked(ctx context.Context, out io.Writer, httpClient *http.Client, age
 // runNonBlocking sends the prompt via the chat completions API without
 // waiting for the agent to finish.
 func runNonBlocking(ctx context.Context, out io.Writer, httpClient *http.Client, agentURL, instanceName string) error {
-	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentURL, runMessage)
+	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentclient.CompletionRequest{
+		URL:    agentURL + "/v1/chat/completions",
+		Prompt: runMessage,
+	})
 	if err != nil {
 		return fmt.Errorf("sending prompt to %q: %w", instanceName, err)
 	}
@@ -211,6 +228,55 @@ func runNonBlocking(ctx context.Context, out io.Writer, httpClient *http.Client,
 		Status:   "started",
 	}
 	return renderRunResult(out, result)
+}
+
+// runRunRemote sends the prompt to a remote klaus-gateway endpoint,
+// skipping the local create/container-wait path entirely.
+func runRunRemote(ctx context.Context, cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	instanceName := args[0]
+
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return err
+	}
+
+	target, store, rec, err := resolveRemoteTarget(ctx, runRemote, instanceName, runSession, paths)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Sending prompt to %s (remote: %s)...\n", instanceName, target.BaseURL)
+
+	httpClient := &http.Client{}
+	compCh, err := streamRemoteCompletion(ctx, httpClient, &target, store, rec, runMessage)
+	if err != nil {
+		return fmt.Errorf("sending prompt to %q: %w", instanceName, err)
+	}
+
+	if !runBlocking {
+		go func() {
+			for range compCh {
+			}
+		}()
+		return renderRunResult(out, promptCLIResult{
+			Instance: instanceName,
+			Status:   "started",
+		})
+	}
+
+	for delta := range compCh {
+		if delta.Err != nil {
+			return fmt.Errorf("streaming from %q: %w", instanceName, delta.Err)
+		}
+		fmt.Fprint(out, delta.Content)
+	}
+	fmt.Fprintln(out)
+
+	return renderRunResult(out, promptCLIResult{
+		Instance: instanceName,
+		Status:   "completed",
+	})
 }
 
 func renderRunResult(out io.Writer, result promptCLIResult) error {

--- a/docs/gatewaybridge.md
+++ b/docs/gatewaybridge.md
@@ -7,6 +7,11 @@ spawns the process, tracks PID/port, health-checks `/healthz`, and registers
 the resulting MCP HTTP endpoint in `~/.config/klausctl/mcpservers.yaml` so
 containerized klaus instances can reach it via `host.docker.internal`.
 
+For the opposite direction -- a klausctl user reaching a remote gateway
+rather than spawning a local one -- see [docs/remote.md](remote.md). The
+`--remote=URL` flag on `run`/`prompt`/`messages` targets a remote
+`klaus-gateway` and skips the local bridge entirely.
+
 ## CLI
 
 ```

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -1,0 +1,134 @@
+# Remote klaus-gateway targeting
+
+`klausctl run`, `klausctl prompt`, and `klausctl messages` can target a
+remote `klaus-gateway` instead of a local klaus container. When `--remote=URL`
+is set, the named instance is treated as a logical instance hosted by the
+gateway: no local container is created, no local port file is read, and no
+workspace is mounted. Requests flow directly to the gateway's
+`/v1/{instance}/chat/completions` and `/v1/{instance}/mcp` endpoints.
+
+This is the counterpart to the [local gateway bridge](gatewaybridge.md):
+the bridge lets a local agent reach a local gateway; `--remote` lets a CLI
+user reach someone else's gateway.
+
+## Quick start
+
+```bash
+# Authenticate once per gateway host (browser-based OAuth).
+klausctl auth login --remote=https://gw.example.com
+
+# Run a prompt against a gateway-hosted instance.
+klausctl run my-bot --remote=https://gw.example.com -m "summarise the week"
+
+# Follow an existing conversation.
+klausctl prompt my-bot --remote=https://gw.example.com -m "and last Friday?"
+
+# Inspect saved messages for an instance.
+klausctl messages my-bot --remote=https://gw.example.com
+```
+
+The same inputs are available on the MCP tools served by `klausctl serve`:
+`klaus_run`, `klaus_prompt`, and `klaus_messages` each accept `remote` and
+`session` alongside their existing parameters. A parity test in
+`cmd/remote_parity_test.go` fails the build if the CLI and MCP surfaces
+drift.
+
+## Flags
+
+Both `--remote` and `--session` are declared once in
+`internal/remotesurface` so the three subcommands and three MCP tools stay
+in lock-step.
+
+- `--remote=URL` -- gateway base URL. When set, the target is the gateway
+  and no local container is inspected or spawned. A trailing `/v1` is
+  stripped so `https://gw.example.com` and `https://gw.example.com/v1`
+  both work.
+- `--session=NAME` -- session (thread) identity forwarded as
+  `X-Klaus-Thread-ID`. When omitted, klausctl derives a stable value from
+  a SHA-256 of the current working directory so repeated invocations from
+  the same checkout land on the same conversation thread.
+
+## Authentication
+
+`klausctl auth login --remote=URL` runs the standard browser-based OAuth
+flow (the same PKCE/CIMD client used for muster federations) and stores
+the resulting tokens under:
+
+```
+~/.config/klausctl/auth/<host>[_port].yaml
+```
+
+with directory mode `0700` and file mode `0600`. Each record captures the
+access token, refresh token, expiry, granted scopes, and the cached token
+endpoint + client ID so refresh does not need to repeat discovery.
+
+Related commands:
+
+```
+klausctl auth login  --remote=URL
+klausctl auth status
+klausctl auth logout --remote=URL
+```
+
+### Token refresh
+
+Tokens are refreshed in two places so a stale access token never surfaces
+to the user as a cryptic 401:
+
+1. **Proactive (pre-call):** `resolveRemoteTarget` consults the cached
+   record and refreshes when `ExpiresAt` is within 60 seconds.
+2. **Reactive (on 401):** `streamRemoteCompletion` and the equivalent MCP
+   handler retry the request exactly once after refreshing.
+
+If either refresh path is rejected by the OAuth server (typically because
+the refresh token was revoked or expired beyond its grace period),
+klausctl returns a `re-run 'klausctl auth login --remote=URL'` hint
+rather than a generic OAuth error.
+
+## Routing headers
+
+Every gateway call carries the following headers so operators can route
+and log requests consistently:
+
+| Header                 | Value                                                                |
+|------------------------|----------------------------------------------------------------------|
+| `X-Klaus-Channel`      | `cli` (constant; identifies klausctl)                                |
+| `X-Klaus-Channel-ID`   | `os.Hostname()` (falls back to `unknown`)                            |
+| `X-Klaus-User-ID`      | JWT `sub` claim when the bearer parses, else `$USER` / `$LOGNAME`    |
+| `X-Klaus-Thread-ID`    | `--session` value, or `cwd-<sha256(cwd)[0:16]>`                      |
+| `Authorization`        | `Bearer <access_token>` when an auth record exists                   |
+
+The same header set is applied to both the completions stream (HTTP POST
+with SSE response) and the MCP streamable-HTTP session used by
+`klausctl messages`. See `pkg/remote/target.go` for the resolution rules
+and `pkg/mcpclient/client.go` (`NewWithHeaders`) for the MCP integration.
+
+## URL composition
+
+For a base URL `https://gw.example.com` and instance name `my-bot`:
+
+- Chat completions: `POST https://gw.example.com/v1/my-bot/chat/completions`
+- MCP endpoint:     `https://gw.example.com/v1/my-bot/mcp`
+
+The instance name is percent-encoded so names containing characters
+outside the DNS-label grammar still produce a valid URL.
+
+## Local mode remains unchanged
+
+When `--remote` is **not** set, the three subcommands keep the exact
+byte-for-byte wire format they had before this feature: the same local
+port lookup, the same `http://localhost:<port>/v1/chat/completions`
+endpoint, no `Authorization` header, and no `X-Klaus-*` headers. Nothing
+in the local path checks any auth state.
+
+## File layout
+
+```
+~/.config/klausctl/
+  auth/                    # 0700
+    gw.example.com.yaml    # 0600 per-host OAuth record
+    gw.other.example:8080.yaml
+```
+
+Delete the directory (or use `klausctl auth logout`) to sign out of a
+gateway. The next remote call will fail with the re-login hint.

--- a/internal/remotesurface/surface.go
+++ b/internal/remotesurface/surface.go
@@ -1,0 +1,48 @@
+// Package remotesurface declares the `--remote` and `--session` flags that
+// are shared by `klausctl run`, `klausctl prompt`, and `klausctl messages`
+// plus the corresponding MCP tools (klaus_run, klaus_prompt, klaus_messages).
+//
+// Both the Cobra commands and the MCP tool registrations consume this
+// package so the two surfaces cannot drift. A parity test in
+// cmd/remote_parity_test.go asserts that every CLI flag has an MCP
+// equivalent and vice versa, across all three subcommands/tools.
+package remotesurface
+
+// Flag is a single CLI/MCP surface entry. CLIFlag is the Cobra flag name
+// (kebab-case), MCPKey is the MCP input parameter name (camelCase), Kind
+// names the value type ("bool", "int", "string"), and Description is the
+// human-readable summary shown in both surfaces.
+type Flag struct {
+	CLIFlag     string
+	MCPKey      string
+	Kind        string
+	Description string
+}
+
+// Flags lists the remote-targeting inputs accepted by `run`, `prompt`, and
+// `messages` (CLI) and `klaus_run`, `klaus_prompt`, `klaus_messages` (MCP).
+var Flags = []Flag{
+	{
+		CLIFlag:     "remote",
+		MCPKey:      "remote",
+		Kind:        "string",
+		Description: "Remote klaus-gateway base URL; when set, the target is the gateway and no local container is inspected or spawned.",
+	},
+	{
+		CLIFlag:     "session",
+		MCPKey:      "session",
+		Kind:        "string",
+		Description: "Session (thread) name forwarded as X-Klaus-Thread-ID (default: stable hash of the current working directory).",
+	},
+}
+
+// CLIFlagByKey returns the Flag entry for a given CLIFlag name, panicking
+// on an unknown key. Use this in Cobra bindings so typos fail at init time.
+func CLIFlagByKey(key string) Flag {
+	for _, f := range Flags {
+		if f.CLIFlag == key {
+			return f
+		}
+	}
+	panic("unknown remote flag: " + key)
+}

--- a/internal/tools/instance/agent.go
+++ b/internal/tools/instance/agent.go
@@ -26,6 +26,7 @@ func registerPrompt(s *mcpserver.MCPServer, sc *server.ServerContext) {
 		mcp.WithString("message", mcp.Required(), mcp.Description("Prompt message to send to the agent")),
 		mcp.WithBoolean("blocking", mcp.Description("Wait for the agent to complete and return the result (default: false)")),
 	)
+	addRemoteMCPInputs(&tool)
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handlePrompt(ctx, req, sc)
 	})
@@ -59,6 +60,10 @@ func handlePrompt(ctx context.Context, req mcp.CallToolRequest, sc *server.Serve
 	}
 	blocking := req.GetBool("blocking", false)
 
+	if req.GetString("remote", "") != "" {
+		return handlePromptRemote(ctx, req, sc, name, message, blocking)
+	}
+
 	baseURL, err := agentBaseURL(ctx, name, sc)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -67,7 +72,10 @@ func handlePrompt(ctx context.Context, req mcp.CallToolRequest, sc *server.Serve
 	agentURL := strings.TrimSuffix(baseURL, "/mcp")
 	httpClient := &http.Client{}
 
-	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentURL, message)
+	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentclient.CompletionRequest{
+		URL:    agentURL + "/v1/chat/completions",
+		Prompt: message,
+	})
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("sending prompt to %q: %v", name, err)), nil
 	}
@@ -95,6 +103,46 @@ func handlePrompt(ctx context.Context, req mcp.CallToolRequest, sc *server.Serve
 		Instance: name,
 		Status:   "completed",
 		Result:   mcpclient.ExtractText(resultResp),
+	})
+}
+
+// handlePromptRemote services klaus_prompt when `remote` is set: the
+// prompt is forwarded to <remote>/v1/<name>/chat/completions with the
+// routing headers and bearer attached.
+func handlePromptRemote(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerContext, name, message string, blocking bool) (*mcp.CallToolResult, error) {
+	call, err := remoteFromReq(ctx, req, sc, name)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	compCh, err := call.streamRemotePrompt(ctx, &http.Client{}, message)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("sending prompt to %q via %s: %v", name, call.Target.BaseURL, err)), nil
+	}
+
+	if !blocking {
+		go func() {
+			for range compCh {
+			}
+		}()
+		return server.JSONResult(promptResult{
+			Instance: name,
+			Status:   "started",
+		})
+	}
+
+	var builder []byte
+	for delta := range compCh {
+		if delta.Err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("streaming from %q: %v", name, delta.Err)), nil
+		}
+		builder = append(builder, delta.Content...)
+	}
+
+	return server.JSONResult(promptResult{
+		Instance: name,
+		Status:   "completed",
+		Result:   string(builder),
 	})
 }
 
@@ -173,6 +221,7 @@ func registerMessages(s *mcpserver.MCPServer, sc *server.ServerContext) {
 		mcp.WithString("types", mcp.Description("Comma-separated message types to include (e.g. 'user,assistant,tool')")),
 		mcp.WithBoolean("follow", mcp.Description("Poll for new messages until the agent completes (default: false)")),
 	)
+	addRemoteMCPInputs(&tool)
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleMessages(ctx, req, sc)
 	})
@@ -187,19 +236,89 @@ func handleMessages(ctx context.Context, req mcp.CallToolRequest, sc *server.Ser
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	follow := req.GetBool("follow", false)
+	opts := messagesOptsFromReq(req)
+
+	if req.GetString("remote", "") != "" {
+		return handleMessagesRemote(ctx, req, sc, name, follow, opts)
+	}
 
 	baseURL, err := agentBaseURL(ctx, name, sc)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	opts := messagesOptsFromReq(req)
-
 	if !follow {
 		return fetchMessages(ctx, name, baseURL, sc, opts)
 	}
 
 	return followMessagesUntilDone(ctx, name, baseURL, sc, opts)
+}
+
+// handleMessagesRemote routes the MCP messages tool call to a remote
+// klaus-gateway, wrapping mcpclient with the routing headers and bearer.
+func handleMessagesRemote(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerContext, name string, follow bool, opts *mcpclient.MessagesOpts) (*mcp.CallToolResult, error) {
+	call, err := remoteFromReq(ctx, req, sc, name)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	client := mcpclient.NewWithHeaders("mcp", call.mcpHeaders())
+	defer client.Close()
+
+	baseURL := call.Target.MCPURL()
+	if !follow {
+		toolResult, err := client.Messages(ctx, name, baseURL, opts)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("fetching messages from %q via %s: %v", name, call.Target.BaseURL, err)), nil
+		}
+		if toolResult.IsError {
+			return toolResult, nil
+		}
+		return mcp.NewToolResultText(mcpclient.ExtractText(toolResult)), nil
+	}
+
+	return followRemoteMessages(ctx, name, baseURL, client, opts)
+}
+
+func followRemoteMessages(ctx context.Context, name, baseURL string, client *mcpclient.Client, opts *mcpclient.MessagesOpts) (*mcp.CallToolResult, error) {
+	const maxFollowDuration = 30 * time.Minute
+	ctx, cancel := context.WithTimeout(ctx, maxFollowDuration)
+	defer cancel()
+
+	poll := 2 * time.Second
+	const maxPoll = 10 * time.Second
+
+	var lastResult *mcp.CallToolResult
+
+	for {
+		toolResult, err := client.Messages(ctx, name, baseURL, opts)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("fetching messages from %q: %v", name, err)), nil
+		}
+		lastResult = mcp.NewToolResultText(mcpclient.ExtractText(toolResult))
+
+		statusResult, statusErr := client.Status(ctx, name, baseURL)
+		status := ""
+		if statusErr == nil {
+			status = mcpclient.ParseStatusField(statusResult)
+		}
+		if mcpclient.IsTerminalStatus(status) {
+			return lastResult, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			if lastResult != nil {
+				return lastResult, nil
+			}
+			return mcp.NewToolResultError("timed out waiting for messages"), nil
+		case <-time.After(poll):
+		}
+
+		if poll < maxPoll {
+			poll = min(poll*2, maxPoll)
+		}
+	}
 }
 
 func messagesOptsFromReq(req mcp.CallToolRequest) *mcpclient.MessagesOpts {

--- a/internal/tools/instance/remote.go
+++ b/internal/tools/instance/remote.go
@@ -1,0 +1,127 @@
+package instance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/giantswarm/klausctl/internal/server"
+	"github.com/giantswarm/klausctl/pkg/agentclient"
+	"github.com/giantswarm/klausctl/pkg/remote"
+)
+
+const tokenRefreshLeeway = 60 * time.Second
+
+// remoteCall bundles the per-call state for a remote klaus-gateway
+// request: a composed Target (URL + routing headers + bearer), the
+// AuthStore the bearer came from, and the cached AuthRecord used when we
+// have to refresh on 401.
+type remoteCall struct {
+	Target *remote.Target
+	Store  *remote.AuthStore
+	Record *remote.AuthRecord
+}
+
+// remoteFromReq inspects an MCP tool request for `remote` and `session`
+// inputs. When `remote` is empty, the returned *remoteCall is nil and
+// callers should fall through to the local path. When set, it loads
+// (and proactively refreshes) the cached auth record for the host.
+func remoteFromReq(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerContext, instance string) (*remoteCall, error) {
+	remoteURL := req.GetString("remote", "")
+	if remoteURL == "" {
+		return nil, nil
+	}
+	session := req.GetString("session", "")
+
+	normURL, err := remote.NormalizeBaseURL(remoteURL)
+	if err != nil {
+		return nil, err
+	}
+
+	store := remote.NewAuthStore(sc.Paths.AuthDir)
+	rec, err := store.Get(normURL)
+	if err != nil {
+		return nil, fmt.Errorf("reading auth record for %s: %w", normURL, err)
+	}
+
+	var bearer string
+	if rec != nil {
+		if rec.IsExpired(tokenRefreshLeeway) {
+			refreshed, refreshErr := remote.Refresh(ctx, http.DefaultClient, *rec)
+			if refreshErr != nil {
+				var reloginErr *remote.ErrReloginRequired
+				if errors.As(refreshErr, &reloginErr) {
+					return nil, fmt.Errorf("stored credentials for %s are no longer valid; re-run 'klausctl auth login --remote=%s'", normURL, normURL)
+				}
+				return nil, fmt.Errorf("refreshing token for %s: %w", normURL, refreshErr)
+			}
+			if err := store.Put(refreshed); err != nil {
+				return nil, fmt.Errorf("persisting refreshed token: %w", err)
+			}
+			rec = &refreshed
+		}
+		bearer = rec.AccessToken
+	}
+
+	target, err := remote.NewTarget(normURL, instance, session, bearer)
+	if err != nil {
+		return nil, err
+	}
+	return &remoteCall{Target: &target, Store: store, Record: rec}, nil
+}
+
+// streamRemotePrompt sends a prompt via the remote gateway, retrying
+// once on HTTP 401 after refreshing the cached token.
+func (c *remoteCall) streamRemotePrompt(ctx context.Context, httpClient *http.Client, prompt string) (<-chan agentclient.CompletionDelta, error) {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+
+	req := agentclient.CompletionRequest{
+		URL:     c.Target.CompletionsURL(),
+		Prompt:  prompt,
+		Bearer:  c.Target.BearerToken,
+		Headers: c.Target.Headers(),
+	}
+
+	ch, err := agentclient.StreamCompletion(ctx, httpClient, req)
+	if err == nil {
+		return ch, nil
+	}
+
+	var httpErr *agentclient.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusUnauthorized || c.Record == nil {
+		return nil, err
+	}
+
+	refreshed, refreshErr := remote.Refresh(ctx, http.DefaultClient, *c.Record)
+	if refreshErr != nil {
+		var reloginErr *remote.ErrReloginRequired
+		if errors.As(refreshErr, &reloginErr) {
+			return nil, fmt.Errorf("remote %s rejected credentials; re-run 'klausctl auth login --remote=%s'", c.Target.BaseURL, c.Target.BaseURL)
+		}
+		return nil, fmt.Errorf("refreshing token after 401: %w", refreshErr)
+	}
+	if err := c.Store.Put(refreshed); err != nil {
+		return nil, fmt.Errorf("persisting refreshed token: %w", err)
+	}
+
+	c.Target.BearerToken = refreshed.AccessToken
+	c.Record = &refreshed
+	req.Bearer = refreshed.AccessToken
+	return agentclient.StreamCompletion(ctx, httpClient, req)
+}
+
+// mcpHeaders returns the MCP-request header bundle: routing headers +
+// Authorization bearer (when the target has one).
+func (c *remoteCall) mcpHeaders() map[string]string {
+	h := c.Target.Headers()
+	if c.Target.BearerToken != "" {
+		h["Authorization"] = "Bearer " + c.Target.BearerToken
+	}
+	return h
+}

--- a/internal/tools/instance/run.go
+++ b/internal/tools/instance/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
+	"github.com/giantswarm/klausctl/internal/remotesurface"
 	"github.com/giantswarm/klausctl/internal/server"
 	"github.com/giantswarm/klausctl/pkg/agentclient"
 	"github.com/giantswarm/klausctl/pkg/mcpclient"
@@ -46,9 +47,32 @@ func registerRun(s *mcpserver.MCPServer, sc *server.ServerContext) {
 		mcp.WithBoolean("confirm", mcp.Description("Confirm replacement of an existing instance; required when a name collision is detected")),
 		mcp.WithBoolean("blocking", mcp.Description("Wait for the agent to complete and return the result (default: false)")),
 	)
+	addRemoteMCPInputs(&tool)
 	s.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleRun(ctx, req, sc)
 	})
+}
+
+// addRemoteMCPInputs mutates an existing mcp.Tool to attach the
+// `remote` and `session` inputs declared in internal/remotesurface so
+// the MCP tool surface stays in lock-step with the CLI flags.
+func addRemoteMCPInputs(tool *mcp.Tool) {
+	for _, f := range remotesurface.Flags {
+		applyMCPInput(tool, f)
+	}
+}
+
+func applyMCPInput(tool *mcp.Tool, f remotesurface.Flag) {
+	var opt mcp.ToolOption
+	switch f.Kind {
+	case "bool":
+		opt = mcp.WithBoolean(f.MCPKey, mcp.Description(f.Description))
+	case "int":
+		opt = mcp.WithNumber(f.MCPKey, mcp.Description(f.Description))
+	default:
+		opt = mcp.WithString(f.MCPKey, mcp.Description(f.Description))
+	}
+	opt(tool)
 }
 
 type runResult struct {
@@ -68,6 +92,10 @@ func handleRun(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerCo
 	}
 
 	blocking := req.GetBool("blocking", false)
+
+	if name := req.GetString("name", ""); name != "" && req.GetString("remote", "") != "" {
+		return handleRunRemote(ctx, req, sc, name, message, blocking)
+	}
 
 	// Create the instance using the shared create logic.
 	params, err := parseMCPCreateParams(req)
@@ -100,7 +128,10 @@ func handleRun(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerCo
 	}
 
 	// Send the prompt via the chat completions API.
-	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentURL, message)
+	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentclient.CompletionRequest{
+		URL:    agentURL + "/v1/chat/completions",
+		Prompt: message,
+	})
 	if err != nil {
 		return cleanupOnError(fmt.Errorf("sending prompt to %q: %v", name, err))
 	}
@@ -138,5 +169,48 @@ func handleRun(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerCo
 		Workspace: createRes.Workspace,
 		Port:      createRes.Port,
 		Result:    mcpclient.ExtractText(resultResp),
+	})
+}
+
+// handleRunRemote services klaus_run when the `remote` input is set: no
+// container is created and no local state is touched; the prompt flows
+// straight through to the named instance on the remote gateway.
+func handleRunRemote(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerContext, name, message string, blocking bool) (*mcp.CallToolResult, error) {
+	call, err := remoteFromReq(ctx, req, sc, name)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	httpClient := &http.Client{}
+	compCh, err := call.streamRemotePrompt(ctx, httpClient, message)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("sending prompt to %q via %s: %v", name, call.Target.BaseURL, err)), nil
+	}
+
+	if !blocking {
+		go func() {
+			for range compCh {
+			}
+		}()
+		return server.JSONResult(runResult{
+			Instance:  name,
+			Status:    "started",
+			Workspace: call.Target.BaseURL,
+		})
+	}
+
+	var builder []byte
+	for delta := range compCh {
+		if delta.Err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("streaming from %q: %v", name, delta.Err)), nil
+		}
+		builder = append(builder, delta.Content...)
+	}
+
+	return server.JSONResult(runResult{
+		Instance:  name,
+		Status:    "completed",
+		Workspace: call.Target.BaseURL,
+		Result:    string(builder),
 	})
 }

--- a/pkg/agentclient/chat.go
+++ b/pkg/agentclient/chat.go
@@ -20,6 +20,18 @@ type CompletionDelta struct {
 	Err     error
 }
 
+// CompletionRequest describes a single /v1/chat/completions call. URL is
+// the full endpoint (the caller is responsible for composing the
+// instance-scoped path). Bearer and Headers are optional — Bearer becomes
+// an `Authorization: Bearer <token>` header and Headers are applied on
+// top of the default Content-Type/Accept pair.
+type CompletionRequest struct {
+	URL     string
+	Prompt  string
+	Bearer  string
+	Headers map[string]string
+}
+
 // chatCompletionRequest is the POST body for /v1/chat/completions.
 type chatCompletionRequest struct {
 	Model    string           `json:"model"`
@@ -32,16 +44,18 @@ type chatReqMessage struct {
 	Content string `json:"content"`
 }
 
-// StreamCompletion sends a prompt via POST /v1/chat/completions with
+// StreamCompletion sends a prompt via POST to the completions URL with
 // stream=true and returns a channel of deltas. The channel is closed when
 // the stream ends (either cleanly via [DONE] or due to an error).
-func StreamCompletion(ctx context.Context, client *http.Client, baseURL, prompt string) (<-chan CompletionDelta, error) {
-	url := baseURL + "/v1/chat/completions"
-
+//
+// The wire body is identical regardless of whether req.Bearer/Headers are
+// set — local (direct-to-agent) and remote (gateway) callers share the
+// same request shape so the server side sees no difference.
+func StreamCompletion(ctx context.Context, client *http.Client, req CompletionRequest) (<-chan CompletionDelta, error) {
 	body := chatCompletionRequest{
 		Model: "default",
 		Messages: []chatReqMessage{
-			{Role: "user", Content: prompt},
+			{Role: "user", Content: req.Prompt},
 		},
 		Stream: true,
 	}
@@ -50,14 +64,20 @@ func StreamCompletion(ctx context.Context, client *http.Client, baseURL, prompt 
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, req.URL, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "text/event-stream")
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+	for k, v := range req.Headers {
+		httpReq.Header.Set(k, v)
+	}
+	if req.Bearer != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+req.Bearer)
+	}
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("connecting to completions stream: %w", err)
 	}
@@ -65,7 +85,10 @@ func StreamCompletion(ctx context.Context, client *http.Client, baseURL, prompt 
 	if resp.StatusCode != http.StatusOK {
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		resp.Body.Close()
-		return nil, fmt.Errorf("completions returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
+		return nil, &HTTPError{
+			StatusCode: resp.StatusCode,
+			Body:       strings.TrimSpace(string(errBody)),
+		}
 	}
 
 	ch := make(chan CompletionDelta, 16)
@@ -107,4 +130,16 @@ func StreamCompletion(ctx context.Context, client *http.Client, baseURL, prompt 
 	}()
 
 	return ch, nil
+}
+
+// HTTPError is returned by StreamCompletion when the completions endpoint
+// responds with a non-200 status. Callers (notably the remote path) can
+// type-assert on this to trigger refresh-on-401.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("completions returned status %d: %s", e.StatusCode, e.Body)
 }

--- a/pkg/agentclient/chat_test.go
+++ b/pkg/agentclient/chat_test.go
@@ -2,6 +2,7 @@ package agentclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -66,7 +67,7 @@ func TestStreamCompletionBasic(t *testing.T) {
 	)
 	defer srv.Close()
 
-	ch, err := StreamCompletion(context.Background(), srv.Client(), srv.URL, "test prompt")
+	ch, err := StreamCompletion(context.Background(), srv.Client(), CompletionRequest{URL: srv.URL + "/v1/chat/completions", Prompt: "test prompt"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -90,7 +91,7 @@ func TestStreamCompletionEmptyContent(t *testing.T) {
 	)
 	defer srv.Close()
 
-	ch, err := StreamCompletion(context.Background(), srv.Client(), srv.URL, "test")
+	ch, err := StreamCompletion(context.Background(), srv.Client(), CompletionRequest{URL: srv.URL + "/v1/chat/completions", Prompt: "test"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -114,7 +115,7 @@ func TestStreamCompletionSkipsNonDataLines(t *testing.T) {
 	)
 	defer srv.Close()
 
-	ch, err := StreamCompletion(context.Background(), srv.Client(), srv.URL, "test")
+	ch, err := StreamCompletion(context.Background(), srv.Client(), CompletionRequest{URL: srv.URL + "/v1/chat/completions", Prompt: "test"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,12 +135,18 @@ func TestStreamCompletionNon200(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := StreamCompletion(context.Background(), srv.Client(), srv.URL, "test")
+	_, err := StreamCompletion(context.Background(), srv.Client(), CompletionRequest{URL: srv.URL + "/v1/chat/completions", Prompt: "test"})
 	if err == nil {
 		t.Fatal("expected error for non-200 response")
 	}
 	if !strings.Contains(err.Error(), "503") {
 		t.Errorf("error should mention status code, got: %v", err)
+	}
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Errorf("expected *HTTPError, got %T: %v", err, err)
+	} else if httpErr.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("expected StatusCode=503, got %d", httpErr.StatusCode)
 	}
 }
 
@@ -147,7 +154,7 @@ func TestStreamCompletionCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := StreamCompletion(ctx, &http.Client{}, "http://localhost:0", "test")
+	_, err := StreamCompletion(ctx, &http.Client{}, CompletionRequest{URL: "http://localhost:0/v1/chat/completions", Prompt: "test"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
@@ -161,7 +168,7 @@ func TestStreamCompletionMalformedJSON(t *testing.T) {
 	)
 	defer srv.Close()
 
-	ch, err := StreamCompletion(context.Background(), srv.Client(), srv.URL, "test")
+	ch, err := StreamCompletion(context.Background(), srv.Client(), CompletionRequest{URL: srv.URL + "/v1/chat/completions", Prompt: "test"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -183,7 +190,7 @@ func TestStreamCompletionNoChoices(t *testing.T) {
 	)
 	defer srv.Close()
 
-	ch, err := StreamCompletion(context.Background(), srv.Client(), srv.URL, "test")
+	ch, err := StreamCompletion(context.Background(), srv.Client(), CompletionRequest{URL: srv.URL + "/v1/chat/completions", Prompt: "test"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -203,7 +210,7 @@ func TestStreamCompletionChannelClosesWithoutDONE(t *testing.T) {
 	)
 	defer srv.Close()
 
-	ch, err := StreamCompletion(context.Background(), srv.Client(), srv.URL, "test")
+	ch, err := StreamCompletion(context.Background(), srv.Client(), CompletionRequest{URL: srv.URL + "/v1/chat/completions", Prompt: "test"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -221,7 +228,7 @@ func TestStreamCompletionUnreachable(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	_, err := StreamCompletion(ctx, &http.Client{}, "http://127.0.0.1:1", "test")
+	_, err := StreamCompletion(ctx, &http.Client{}, CompletionRequest{URL: "http://127.0.0.1:1/v1/chat/completions", Prompt: "test"})
 	if err == nil {
 		t.Fatal("expected error for unreachable host")
 	}

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -76,6 +76,9 @@ type Paths struct {
 	ReposDir string
 	// WorkspacesFile is the path to the workspace registry (~/.config/klausctl/workspaces.yaml).
 	WorkspacesFile string
+	// AuthDir is the directory for host-keyed remote-gateway OAuth records
+	// (~/.config/klausctl/auth/), used by `klausctl auth login --remote=URL`.
+	AuthDir string
 }
 
 // DefaultPaths returns the default paths using XDG conventions.
@@ -127,6 +130,7 @@ func DefaultPaths() (*Paths, error) {
 		AgentGatewayPortFile:    filepath.Join(base, "agentgateway.port"),
 		ReposDir:                filepath.Join(base, "repos"),
 		WorkspacesFile:          filepath.Join(base, "workspaces.yaml"),
+		AuthDir:                 filepath.Join(base, "auth"),
 	}, nil
 }
 
@@ -210,6 +214,7 @@ func (p *Paths) ForInstance(name string) *Paths {
 		AgentGatewayPortFile:    p.AgentGatewayPortFile,
 		ReposDir:                p.ReposDir,
 		WorkspacesFile:          p.WorkspacesFile,
+		AuthDir:                 p.AuthDir,
 	}
 }
 

--- a/pkg/mcpclient/client.go
+++ b/pkg/mcpclient/client.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -18,6 +19,9 @@ type Client struct {
 	mu       sync.Mutex
 	sessions map[string]*mcpclient.Client
 	version  string
+	// headers, when non-empty, are applied to every outgoing MCP HTTP
+	// request (set via NewWithHeaders for the remote-gateway path).
+	headers map[string]string
 }
 
 // New creates a new Client. The version string is sent during MCP session
@@ -26,6 +30,21 @@ func New(version string) *Client {
 	return &Client{
 		sessions: make(map[string]*mcpclient.Client),
 		version:  version,
+	}
+}
+
+// NewWithHeaders returns a Client that attaches the given HTTP headers to
+// every MCP HTTP request. Use this for remote klaus-gateway sessions that
+// need the X-Klaus-* routing headers and/or Authorization bearer.
+func NewWithHeaders(version string, headers map[string]string) *Client {
+	copied := make(map[string]string, len(headers))
+	for k, v := range headers {
+		copied[k] = v
+	}
+	return &Client{
+		sessions: make(map[string]*mcpclient.Client),
+		version:  version,
+		headers:  copied,
 	}
 }
 
@@ -49,7 +68,12 @@ func (c *Client) getOrCreateSession(ctx context.Context, instanceName, baseURL s
 		c.mu.Unlock()
 	}
 
-	mc, err := mcpclient.NewStreamableHttpClient(baseURL)
+	var transportOpts []transport.StreamableHTTPCOption
+	if len(c.headers) > 0 {
+		transportOpts = append(transportOpts, transport.WithHTTPHeaders(c.headers))
+	}
+
+	mc, err := mcpclient.NewStreamableHttpClient(baseURL, transportOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating MCP client for %s: %w", baseURL, err)
 	}

--- a/pkg/remote/auth_store.go
+++ b/pkg/remote/auth_store.go
@@ -1,0 +1,201 @@
+package remote
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// AuthRecord is the per-host credential record persisted on disk.
+//
+// ExpiresAt is the absolute expiry of AccessToken. When the access token is
+// about to expire, callers should refresh using RefreshToken.
+type AuthRecord struct {
+	// ServerURL is the remote klaus-gateway root (normalized).
+	ServerURL string `yaml:"server_url"`
+	// Issuer is the OAuth authorization server issuer URL (from discovery).
+	Issuer string `yaml:"issuer"`
+	// AccessToken is the current access token.
+	AccessToken string `yaml:"access_token"`
+	// TokenType is the token type, typically "Bearer".
+	TokenType string `yaml:"token_type,omitempty"`
+	// RefreshToken is used to mint a new access token without re-login.
+	RefreshToken string `yaml:"refresh_token,omitempty"`
+	// ExpiresAt is the absolute expiry time of AccessToken.
+	ExpiresAt time.Time `yaml:"expires_at,omitempty"`
+	// Scope is the scope granted for the access token, if reported.
+	Scope string `yaml:"scope,omitempty"`
+	// TokenEndpoint is the OAuth token endpoint (cached so refresh can
+	// proceed without repeating discovery).
+	TokenEndpoint string `yaml:"token_endpoint,omitempty"`
+	// ClientID is the OAuth client identifier used during the original
+	// authorization (typically the CIMD URL).
+	ClientID string `yaml:"client_id,omitempty"`
+}
+
+// IsExpired reports whether the access token is expired or will expire
+// within the given leeway. Zero ExpiresAt is treated as non-expiring.
+func (r *AuthRecord) IsExpired(leeway time.Duration) bool {
+	if r.ExpiresAt.IsZero() {
+		return false
+	}
+	return time.Now().Add(leeway).After(r.ExpiresAt)
+}
+
+// AuthStore manages host-keyed OAuth records at ~/.config/klausctl/auth/.
+// Files are written with 0600 and the parent directory with 0700.
+type AuthStore struct {
+	dir string
+}
+
+// NewAuthStore returns an AuthStore backed by the given directory.
+func NewAuthStore(dir string) *AuthStore {
+	return &AuthStore{dir: dir}
+}
+
+// Dir returns the directory backing the store.
+func (s *AuthStore) Dir() string { return s.dir }
+
+// Get returns the stored record for the given server URL, or nil when
+// none exists. Only read errors other than ENOENT surface as errors.
+func (s *AuthStore) Get(serverURL string) (*AuthRecord, error) {
+	fileName, err := hostFilename(serverURL)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filepath.Join(s.dir, fileName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading auth record for %s: %w", serverURL, err)
+	}
+	var rec AuthRecord
+	if err := yaml.Unmarshal(data, &rec); err != nil {
+		return nil, fmt.Errorf("parsing auth record for %s: %w", serverURL, err)
+	}
+	return &rec, nil
+}
+
+// Put writes a record for the given server URL with file mode 0600.
+func (s *AuthStore) Put(rec AuthRecord) error {
+	if rec.ServerURL == "" {
+		return fmt.Errorf("auth record has empty server_url")
+	}
+	fileName, err := hostFilename(rec.ServerURL)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("creating auth directory: %w", err)
+	}
+	data, err := yaml.Marshal(&rec)
+	if err != nil {
+		return fmt.Errorf("marshaling auth record: %w", err)
+	}
+	path := filepath.Join(s.dir, fileName)
+	return writeFileAtomic0600(path, data)
+}
+
+// Delete removes the record for the given server URL. Missing files are
+// treated as success.
+func (s *AuthStore) Delete(serverURL string) error {
+	fileName, err := hostFilename(serverURL)
+	if err != nil {
+		return err
+	}
+	err = os.Remove(filepath.Join(s.dir, fileName))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("deleting auth record for %s: %w", serverURL, err)
+	}
+	return nil
+}
+
+// List returns all stored records sorted by server URL.
+func (s *AuthStore) List() ([]AuthRecord, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing auth directory: %w", err)
+	}
+	var out []AuthRecord
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(s.dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var rec AuthRecord
+		if err := yaml.Unmarshal(data, &rec); err != nil {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out, nil
+}
+
+// writeFileAtomic0600 writes data via a tempfile rename so concurrent
+// readers never see a partially-written file. Final mode is 0600.
+func writeFileAtomic0600(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".auth-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp auth file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("writing auth file: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("setting auth file permissions: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("closing auth file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("renaming auth file to %s: %w", path, err)
+	}
+	return nil
+}
+
+// hostFilename derives the on-disk filename for a server URL. We use
+// "<host>[_port].yaml" so records are human-identifiable on the
+// filesystem while still being collision-safe (the URL is re-validated on
+// read via ServerURL inside the file).
+//
+// Unsafe characters are replaced with "_" so filesystem constraints
+// (Windows, macOS) are respected.
+func hostFilename(serverURL string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(serverURL))
+	if err != nil {
+		return "", fmt.Errorf("parsing server URL %q: %w", serverURL, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("server URL %q has no host", serverURL)
+	}
+	name := strings.ToLower(u.Host)
+	name = unsafeFilenameChars.ReplaceAllString(name, "_")
+	return name + ".yaml", nil
+}
+
+var unsafeFilenameChars = regexp.MustCompile(`[^a-z0-9._-]`)

--- a/pkg/remote/auth_store_test.go
+++ b/pkg/remote/auth_store_test.go
@@ -1,0 +1,226 @@
+package remote
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAuthStoreRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	store := NewAuthStore(filepath.Join(dir, "auth"))
+
+	rec := AuthRecord{
+		ServerURL:     "https://gw.example.com",
+		Issuer:        "https://auth.example.com",
+		AccessToken:   "at-123",
+		TokenType:     "Bearer",
+		RefreshToken:  "rt-abc",
+		ExpiresAt:     time.Now().Add(1 * time.Hour).UTC().Round(time.Second),
+		Scope:         "openid profile",
+		TokenEndpoint: "https://auth.example.com/oauth/token",
+		ClientID:      "cimd://client-id-url",
+	}
+	if err := store.Put(rec); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := store.Get(rec.ServerURL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected record, got nil")
+	}
+	if got.AccessToken != rec.AccessToken || got.RefreshToken != rec.RefreshToken {
+		t.Errorf("tokens not preserved: got %+v want %+v", got, rec)
+	}
+	if got.TokenEndpoint != rec.TokenEndpoint || got.ClientID != rec.ClientID {
+		t.Errorf("token endpoint/client id not preserved: got %+v", got)
+	}
+	if !got.ExpiresAt.Equal(rec.ExpiresAt) {
+		t.Errorf("expires_at: got %v want %v", got.ExpiresAt, rec.ExpiresAt)
+	}
+}
+
+func TestAuthStoreGetMissingReturnsNil(t *testing.T) {
+	store := NewAuthStore(t.TempDir())
+	got, err := store.Get("https://gw.example.com")
+	if err != nil {
+		t.Fatalf("Get on empty store: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil record for missing host, got %+v", got)
+	}
+}
+
+func TestAuthStoreFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permissions only")
+	}
+	dir := filepath.Join(t.TempDir(), "auth")
+	store := NewAuthStore(dir)
+	rec := AuthRecord{ServerURL: "https://gw.example.com", AccessToken: "tok"}
+	if err := store.Put(rec); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	fileName, _ := hostFilename(rec.ServerURL)
+	fi, err := os.Stat(filepath.Join(dir, fileName))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("file perm = %o, want 0600", got)
+	}
+
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if got := di.Mode().Perm(); got != 0o700 {
+		t.Errorf("dir perm = %o, want 0700", got)
+	}
+}
+
+func TestAuthStoreDelete(t *testing.T) {
+	store := NewAuthStore(t.TempDir())
+	rec := AuthRecord{ServerURL: "https://gw.example.com", AccessToken: "tok"}
+	if err := store.Put(rec); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := store.Delete(rec.ServerURL); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	// Second delete should be a no-op.
+	if err := store.Delete(rec.ServerURL); err != nil {
+		t.Fatalf("second Delete: %v", err)
+	}
+	got, _ := store.Get(rec.ServerURL)
+	if got != nil {
+		t.Errorf("expected record removed, still got %+v", got)
+	}
+}
+
+func TestAuthStoreList(t *testing.T) {
+	store := NewAuthStore(t.TempDir())
+	recs := []AuthRecord{
+		{ServerURL: "https://a.example.com", AccessToken: "a"},
+		{ServerURL: "https://b.example.com", AccessToken: "b"},
+		{ServerURL: "https://c.example.com:8080", AccessToken: "c"},
+	}
+	for _, r := range recs {
+		if err := store.Put(r); err != nil {
+			t.Fatalf("Put %s: %v", r.ServerURL, err)
+		}
+	}
+	got, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != len(recs) {
+		t.Fatalf("List returned %d entries, want %d", len(got), len(recs))
+	}
+	var urls []string
+	for _, r := range got {
+		urls = append(urls, r.ServerURL)
+	}
+	sort.Strings(urls)
+	if urls[0] != "https://a.example.com" || urls[1] != "https://b.example.com" || urls[2] != "https://c.example.com:8080" {
+		t.Errorf("List returned unexpected URLs: %v", urls)
+	}
+}
+
+func TestAuthStoreListEmptyDir(t *testing.T) {
+	store := NewAuthStore(filepath.Join(t.TempDir(), "does-not-exist"))
+	got, err := store.List()
+	if err != nil {
+		t.Fatalf("List on missing dir: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil on empty store, got %+v", got)
+	}
+}
+
+func TestAuthStorePutRejectsEmptyServerURL(t *testing.T) {
+	store := NewAuthStore(t.TempDir())
+	if err := store.Put(AuthRecord{AccessToken: "x"}); err == nil {
+		t.Fatalf("expected error for empty server_url")
+	}
+}
+
+func TestHostFilename(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"https://gw.example.com", "gw.example.com.yaml"},
+		{"https://GW.Example.com", "gw.example.com.yaml"},
+		{"https://gw.example.com:8080", "gw.example.com_8080.yaml"},
+		{"http://localhost:8080", "localhost_8080.yaml"},
+	}
+	for _, tc := range cases {
+		got, err := hostFilename(tc.in)
+		if err != nil {
+			t.Errorf("hostFilename(%q) error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("hostFilename(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestHostFilenameRejectsEmpty(t *testing.T) {
+	if _, err := hostFilename(""); err == nil {
+		t.Fatal("expected error on empty URL")
+	}
+	if _, err := hostFilename("not-a-url"); err == nil {
+		t.Fatal("expected error on URL with no host")
+	}
+}
+
+func TestAuthRecordIsExpired(t *testing.T) {
+	zero := &AuthRecord{}
+	if zero.IsExpired(0) {
+		t.Error("zero ExpiresAt should be treated as non-expiring")
+	}
+	past := &AuthRecord{ExpiresAt: time.Now().Add(-1 * time.Minute)}
+	if !past.IsExpired(0) {
+		t.Error("past ExpiresAt should be expired")
+	}
+	future := &AuthRecord{ExpiresAt: time.Now().Add(10 * time.Minute)}
+	if future.IsExpired(0) {
+		t.Error("future ExpiresAt with zero leeway should not be expired")
+	}
+	if !future.IsExpired(20 * time.Minute) {
+		t.Error("leeway larger than remaining time should mark as expired")
+	}
+}
+
+func TestWriteFileAtomic0600CreatesNoTempLeftover(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permissions only")
+	}
+	dir := filepath.Join(t.TempDir(), "auth")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, "x.yaml")
+	if err := writeFileAtomic0600(path, []byte("data")); err != nil {
+		t.Fatalf("writeFileAtomic0600: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".auth-") {
+			t.Errorf("temp file leaked: %s", e.Name())
+		}
+	}
+}

--- a/pkg/remote/login.go
+++ b/pkg/remote/login.go
@@ -1,0 +1,219 @@
+package remote
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/klausctl/pkg/oauth"
+)
+
+// LoginOptions controls Login behaviour. Fields left at zero fall back
+// to sensible defaults (CIMD URL, default scopes, http.DefaultClient).
+type LoginOptions struct {
+	// ClientID is the OAuth client identifier; defaults to the public
+	// CIMD URL (oauth.DefaultClientIDMetadataURL).
+	ClientID string
+	// Scopes is the space-separated scope string to request. Defaults
+	// to "openid profile email groups offline_access".
+	Scopes string
+	// HTTPClient is used for the token exchange; defaults to
+	// http.DefaultClient when nil.
+	HTTPClient *http.Client
+	// BrowserOpener opens the authorize URL in the user's browser.
+	// Defaults to oauth.OpenBrowser.
+	BrowserOpener func(string) error
+}
+
+const defaultScopes = "openid profile email groups offline_access"
+
+// Login performs browser-based OAuth login against a remote klaus-gateway
+// and persists the resulting credentials in the given AuthStore. It
+// reuses the pkg/oauth helpers for discovery/PKCE/callback and implements
+// the authorization-URL build + token exchange locally so the resulting
+// AuthRecord captures the token endpoint and client id needed for later
+// refresh-on-401 in pkg/remote/refresh.go.
+func Login(ctx context.Context, store *AuthStore, serverURL string, opts LoginOptions) (*AuthRecord, error) {
+	normURL, err := NormalizeBaseURL(serverURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.ClientID == "" {
+		opts.ClientID = oauth.DefaultClientIDMetadataURL
+	}
+	if opts.Scopes == "" {
+		opts.Scopes = defaultScopes
+	}
+	if opts.HTTPClient == nil {
+		opts.HTTPClient = http.DefaultClient
+	}
+	if opts.BrowserOpener == nil {
+		opts.BrowserOpener = oauth.OpenBrowser
+	}
+
+	issuer, err := discoverIssuer(ctx, normURL)
+	if err != nil {
+		return nil, fmt.Errorf("discovering issuer for %s: %w", normURL, err)
+	}
+
+	meta, err := oauth.DiscoverMetadata(ctx, issuer)
+	if err != nil {
+		return nil, fmt.Errorf("discovering OAuth metadata: %w", err)
+	}
+
+	pkce := oauth.GeneratePKCE()
+	state, err := randomState()
+	if err != nil {
+		return nil, fmt.Errorf("generating state: %w", err)
+	}
+
+	cb := oauth.NewCallbackServer(state)
+	redirectURI, err := cb.Start()
+	if err != nil {
+		return nil, fmt.Errorf("starting callback server: %w", err)
+	}
+
+	authURL := buildAuthorizeURL(meta.AuthorizationEndpoint, opts.ClientID, redirectURI, state, opts.Scopes, pkce)
+
+	fmt.Printf("Opening browser for authentication against %s...\n", issuer)
+	fmt.Printf("If the browser does not open, visit:\n  %s\n\n", authURL)
+
+	if err := opts.BrowserOpener(authURL); err != nil {
+		fmt.Printf("Could not open browser automatically: %v\n", err)
+	}
+
+	result, err := cb.WaitForCallback(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("waiting for callback: %w", err)
+	}
+
+	tok, err := exchangeAuthorizationCode(ctx, opts.HTTPClient, meta.TokenEndpoint, opts.ClientID, redirectURI, result.Code, pkce.Verifier)
+	if err != nil {
+		return nil, fmt.Errorf("exchanging authorization code: %w", err)
+	}
+
+	rec := AuthRecord{
+		ServerURL:     normURL,
+		Issuer:        issuer,
+		AccessToken:   tok.AccessToken,
+		TokenType:     tok.TokenType,
+		RefreshToken:  tok.RefreshToken,
+		Scope:         tok.Scope,
+		TokenEndpoint: meta.TokenEndpoint,
+		ClientID:      opts.ClientID,
+	}
+	if tok.ExpiresIn > 0 {
+		rec.ExpiresAt = time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second)
+	}
+
+	if err := store.Put(rec); err != nil {
+		return nil, fmt.Errorf("storing credentials: %w", err)
+	}
+	return &rec, nil
+}
+
+// discoverIssuer resolves the issuer URL for a klaus-gateway by probing
+// its MCP endpoint. Klaus-gateway exposes OAuth-protected resource
+// metadata at `<base>/v1/mcp` (or returns 401 with WWW-Authenticate).
+func discoverIssuer(ctx context.Context, baseURL string) (string, error) {
+	probeURL := baseURL + "/mcp"
+
+	challenge, err := oauth.ProbeServer(ctx, probeURL)
+	if err != nil {
+		return "", fmt.Errorf("probing %s: %w", probeURL, err)
+	}
+	if challenge == nil {
+		return "", fmt.Errorf("%s does not require OAuth authentication", probeURL)
+	}
+
+	if challenge.Realm != "" {
+		return challenge.Realm, nil
+	}
+	if challenge.ResourceMetadata == "" {
+		return "", fmt.Errorf("WWW-Authenticate at %s contained no realm or resource_metadata", probeURL)
+	}
+	resMeta, err := oauth.FetchResourceMetadata(ctx, challenge.ResourceMetadata)
+	if err != nil {
+		return "", fmt.Errorf("fetching resource metadata: %w", err)
+	}
+	if len(resMeta.AuthorizationServers) == 0 {
+		return "", fmt.Errorf("resource metadata at %s has no authorization_servers", challenge.ResourceMetadata)
+	}
+	return resMeta.AuthorizationServers[0], nil
+}
+
+func buildAuthorizeURL(endpoint, clientID, redirectURI, state, scopes string, pkce oauth.PKCEChallenge) string {
+	params := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"scope":                 {scopes},
+		"state":                 {state},
+		"code_challenge":        {pkce.Challenge},
+		"code_challenge_method": {pkce.ChallengeMethod},
+	}
+	return endpoint + "?" + params.Encode()
+}
+
+// tokenEndpointResponse captures the subset of RFC 6749 response fields
+// we persist.
+type tokenEndpointResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+func exchangeAuthorizationCode(ctx context.Context, httpClient *http.Client, tokenEndpoint, clientID, redirectURI, code, verifier string) (*tokenEndpointResponse, error) {
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {clientID},
+		"redirect_uri":  {redirectURI},
+		"code":          {code},
+		"code_verifier": {verifier},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("building token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token endpoint returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var tok tokenEndpointResponse
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return nil, fmt.Errorf("parsing token response: %w", err)
+	}
+	if tok.AccessToken == "" {
+		return nil, fmt.Errorf("token response missing access_token")
+	}
+	return &tok, nil
+}
+
+func randomState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/pkg/remote/refresh.go
+++ b/pkg/remote/refresh.go
@@ -1,0 +1,117 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ErrReloginRequired is returned when the stored refresh token is missing
+// or the OAuth server rejects it. Callers surface this to the user as a
+// prompt to re-run `klausctl auth login --remote=...`.
+type ErrReloginRequired struct {
+	ServerURL string
+	Reason    string
+}
+
+func (e *ErrReloginRequired) Error() string {
+	if e.Reason == "" {
+		return fmt.Sprintf("re-authentication required for %s", e.ServerURL)
+	}
+	return fmt.Sprintf("re-authentication required for %s: %s", e.ServerURL, e.Reason)
+}
+
+// refreshResponse is the subset of an RFC 6749 token endpoint reply that
+// we care about for the refresh grant.
+type refreshResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+// Refresh exchanges the refresh token stored in rec for a new access
+// token via the cached token endpoint. The updated record (same fields,
+// new AccessToken/ExpiresAt/RefreshToken) is returned; callers are
+// responsible for persisting it with AuthStore.Put.
+//
+// If the server rejects the refresh (401/invalid_grant) Refresh returns
+// *ErrReloginRequired so the caller can surface a "re-run auth login"
+// hint to the user.
+func Refresh(ctx context.Context, httpClient *http.Client, rec AuthRecord) (AuthRecord, error) {
+	if rec.RefreshToken == "" {
+		return rec, &ErrReloginRequired{ServerURL: rec.ServerURL, Reason: "no refresh token stored"}
+	}
+	if rec.TokenEndpoint == "" {
+		return rec, &ErrReloginRequired{ServerURL: rec.ServerURL, Reason: "no token endpoint cached"}
+	}
+
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {rec.RefreshToken},
+	}
+	if rec.ClientID != "" {
+		form.Set("client_id", rec.ClientID)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rec.TokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return rec, fmt.Errorf("building refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return rec, fmt.Errorf("refresh request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusBadRequest {
+		return rec, &ErrReloginRequired{
+			ServerURL: rec.ServerURL,
+			Reason:    fmt.Sprintf("refresh rejected (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body))),
+		}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return rec, fmt.Errorf("refresh returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload refreshResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return rec, fmt.Errorf("parsing refresh response: %w", err)
+	}
+	if payload.AccessToken == "" {
+		return rec, fmt.Errorf("refresh response missing access_token")
+	}
+
+	updated := rec
+	updated.AccessToken = payload.AccessToken
+	if payload.TokenType != "" {
+		updated.TokenType = payload.TokenType
+	}
+	if payload.RefreshToken != "" {
+		updated.RefreshToken = payload.RefreshToken
+	}
+	if payload.ExpiresIn > 0 {
+		updated.ExpiresAt = time.Now().Add(time.Duration(payload.ExpiresIn) * time.Second)
+	} else {
+		updated.ExpiresAt = time.Time{}
+	}
+	if payload.Scope != "" {
+		updated.Scope = payload.Scope
+	}
+	return updated, nil
+}

--- a/pkg/remote/refresh_test.go
+++ b/pkg/remote/refresh_test.go
@@ -1,0 +1,150 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestRefreshSuccess(t *testing.T) {
+	var gotForm url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		parsed, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatalf("parse form body: %v", err)
+		}
+		gotForm = parsed
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "new-access",
+			"token_type":    "Bearer",
+			"refresh_token": "new-refresh",
+			"expires_in":    3600,
+			"scope":         "openid profile",
+		})
+	}))
+	defer srv.Close()
+
+	rec := AuthRecord{
+		ServerURL:     "https://gw.example.com",
+		RefreshToken:  "old-refresh",
+		TokenEndpoint: srv.URL,
+		ClientID:      "cid-123",
+	}
+	updated, err := Refresh(context.Background(), srv.Client(), rec)
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if updated.AccessToken != "new-access" {
+		t.Errorf("AccessToken = %q, want new-access", updated.AccessToken)
+	}
+	if updated.RefreshToken != "new-refresh" {
+		t.Errorf("RefreshToken = %q, want new-refresh", updated.RefreshToken)
+	}
+	if updated.Scope != "openid profile" {
+		t.Errorf("Scope = %q, want openid profile", updated.Scope)
+	}
+	if updated.ExpiresAt.IsZero() || time.Until(updated.ExpiresAt) < 30*time.Minute {
+		t.Errorf("ExpiresAt not set to expected future time: %v", updated.ExpiresAt)
+	}
+
+	if gotForm.Get("grant_type") != "refresh_token" {
+		t.Errorf("grant_type = %q, want refresh_token", gotForm.Get("grant_type"))
+	}
+	if gotForm.Get("refresh_token") != "old-refresh" {
+		t.Errorf("refresh_token form field = %q, want old-refresh", gotForm.Get("refresh_token"))
+	}
+	if gotForm.Get("client_id") != "cid-123" {
+		t.Errorf("client_id form field = %q, want cid-123", gotForm.Get("client_id"))
+	}
+}
+
+func TestRefreshNoRefreshToken(t *testing.T) {
+	rec := AuthRecord{
+		ServerURL:     "https://gw.example.com",
+		TokenEndpoint: "https://auth.example.com/token",
+	}
+	_, err := Refresh(context.Background(), http.DefaultClient, rec)
+	var relogin *ErrReloginRequired
+	if !errors.As(err, &relogin) {
+		t.Fatalf("expected *ErrReloginRequired, got %v (%T)", err, err)
+	}
+}
+
+func TestRefreshNoTokenEndpoint(t *testing.T) {
+	rec := AuthRecord{
+		ServerURL:    "https://gw.example.com",
+		RefreshToken: "rt",
+	}
+	_, err := Refresh(context.Background(), http.DefaultClient, rec)
+	var relogin *ErrReloginRequired
+	if !errors.As(err, &relogin) {
+		t.Fatalf("expected *ErrReloginRequired, got %v (%T)", err, err)
+	}
+}
+
+func TestRefresh401YieldsReloginRequired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer srv.Close()
+
+	rec := AuthRecord{
+		ServerURL:     "https://gw.example.com",
+		RefreshToken:  "rt",
+		TokenEndpoint: srv.URL,
+	}
+	_, err := Refresh(context.Background(), srv.Client(), rec)
+	var relogin *ErrReloginRequired
+	if !errors.As(err, &relogin) {
+		t.Fatalf("expected *ErrReloginRequired on 401, got %v (%T)", err, err)
+	}
+}
+
+func TestRefresh400YieldsReloginRequired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer srv.Close()
+
+	rec := AuthRecord{
+		ServerURL:     "https://gw.example.com",
+		RefreshToken:  "rt",
+		TokenEndpoint: srv.URL,
+	}
+	_, err := Refresh(context.Background(), srv.Client(), rec)
+	var relogin *ErrReloginRequired
+	if !errors.As(err, &relogin) {
+		t.Fatalf("expected *ErrReloginRequired on 400, got %v (%T)", err, err)
+	}
+}
+
+func TestRefresh500ReturnsGenericError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	rec := AuthRecord{
+		ServerURL:     "https://gw.example.com",
+		RefreshToken:  "rt",
+		TokenEndpoint: srv.URL,
+	}
+	_, err := Refresh(context.Background(), srv.Client(), rec)
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	var relogin *ErrReloginRequired
+	if errors.As(err, &relogin) {
+		t.Errorf("5xx should not be classified as relogin: %v", err)
+	}
+}

--- a/pkg/remote/target.go
+++ b/pkg/remote/target.go
@@ -1,0 +1,237 @@
+// Package remote implements the client-side wiring for targeting a
+// klaus-gateway instead of a locally-running klaus container.
+//
+// The Target type composes the request URL, the routing headers
+// (X-Klaus-Channel, X-Klaus-Channel-ID, X-Klaus-User-ID, X-Klaus-Thread-ID),
+// and the bearer token used by `klausctl run`, `klausctl prompt`, and
+// `klausctl messages` when `--remote=URL` is set.
+package remote
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
+
+const (
+	// ChannelHeader identifies where a gateway request originated.
+	ChannelHeader = "X-Klaus-Channel"
+	// ChannelIDHeader scopes the channel to a specific identity (hostname).
+	ChannelIDHeader = "X-Klaus-Channel-ID"
+	// UserIDHeader carries the authenticated user identity.
+	UserIDHeader = "X-Klaus-User-ID"
+	// ThreadIDHeader carries the conversation/session identity.
+	ThreadIDHeader = "X-Klaus-Thread-ID"
+
+	// ChannelCLI is the value sent on ChannelHeader for klausctl CLI calls.
+	ChannelCLI = "cli"
+)
+
+// Target describes a remote klaus-gateway endpoint plus the routing
+// identities attached to every request.
+type Target struct {
+	// BaseURL is the gateway root, for example "https://gw.example.com".
+	BaseURL string
+
+	// Instance is the klaus instance name — becomes the `{instance}` path
+	// segment in completions/MCP URLs.
+	Instance string
+
+	// BearerToken is attached as `Authorization: Bearer <token>` when set.
+	BearerToken string
+
+	// ChannelID (hostname) identifies the caller's machine.
+	ChannelID string
+
+	// UserID identifies the authenticated user (JWT `sub` or $USER).
+	UserID string
+
+	// ThreadID identifies the conversation/session (defaults to a stable
+	// hash of the working directory when the user does not set --session).
+	ThreadID string
+}
+
+// CompletionsURL is the OpenAI-compatible chat-completions endpoint for
+// this target: `<base>/v1/<instance>/chat/completions`.
+func (t Target) CompletionsURL() string {
+	return joinURL(t.BaseURL, "/v1/", pathEscape(t.Instance), "/chat/completions")
+}
+
+// MCPURL is the streamable-HTTP MCP endpoint for this target:
+// `<base>/v1/<instance>/mcp`.
+func (t Target) MCPURL() string {
+	return joinURL(t.BaseURL, "/v1/", pathEscape(t.Instance), "/mcp")
+}
+
+// Headers returns the routing header map attached to every gateway call.
+// Callers should merge this into their request headers; empty fields are
+// omitted so the gateway can apply defaults.
+func (t Target) Headers() map[string]string {
+	h := map[string]string{
+		ChannelHeader: ChannelCLI,
+	}
+	if t.ChannelID != "" {
+		h[ChannelIDHeader] = t.ChannelID
+	}
+	if t.UserID != "" {
+		h[UserIDHeader] = t.UserID
+	}
+	if t.ThreadID != "" {
+		h[ThreadIDHeader] = t.ThreadID
+	}
+	return h
+}
+
+// NewTarget composes a Target from a remote URL, instance name, session
+// override (may be empty) and bearer token (may be empty). Channel ID and
+// user ID are resolved from the host environment.
+func NewTarget(remoteURL, instance, session, bearer string) (Target, error) {
+	base, err := NormalizeBaseURL(remoteURL)
+	if err != nil {
+		return Target{}, err
+	}
+	if instance == "" {
+		return Target{}, fmt.Errorf("instance name is required for remote target")
+	}
+
+	return Target{
+		BaseURL:     base,
+		Instance:    instance,
+		BearerToken: bearer,
+		ChannelID:   ResolveChannelID(),
+		UserID:      ResolveUserID(bearer),
+		ThreadID:    resolveThreadID(session),
+	}, nil
+}
+
+// NormalizeBaseURL validates a remote URL and strips any trailing slash
+// and any `/v1` suffix so path composition stays predictable.
+func NormalizeBaseURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("remote URL is empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parsing remote URL %q: %w", raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("remote URL %q must be http or https", raw)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("remote URL %q has no host", raw)
+	}
+
+	// Trim trailing slash and a trailing `/v1` segment so CompletionsURL
+	// never produces `/v1/v1/...`.
+	p := strings.TrimRight(u.Path, "/")
+	p = strings.TrimSuffix(p, "/v1")
+	u.Path = p
+	u.RawQuery = ""
+	u.Fragment = ""
+
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
+// ResolveChannelID returns the host identity used in X-Klaus-Channel-ID.
+// Falls back to "unknown" when the hostname cannot be resolved.
+func ResolveChannelID() string {
+	name, err := os.Hostname()
+	if err != nil || name == "" {
+		return "unknown"
+	}
+	return name
+}
+
+// ResolveUserID extracts the user identity used in X-Klaus-User-ID. It
+// prefers the `sub` claim from the bearer token JWT (if the token parses
+// cleanly), falling back to $USER, then the current uid, then "unknown".
+func ResolveUserID(bearer string) string {
+	if sub := jwtSubject(bearer); sub != "" {
+		return sub
+	}
+	if u := strings.TrimSpace(os.Getenv("USER")); u != "" {
+		return u
+	}
+	if u := strings.TrimSpace(os.Getenv("LOGNAME")); u != "" {
+		return u
+	}
+	return "unknown"
+}
+
+// jwtSubject parses an unsigned JWT (or any token whose middle segment is
+// a base64url-encoded JSON object) and returns its `sub` claim. Returns
+// an empty string on any failure.
+func jwtSubject(token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		// Some IdPs emit padded base64; be lenient.
+		if decoded, derr := base64.URLEncoding.DecodeString(parts[1]); derr == nil {
+			payload = decoded
+		} else {
+			return ""
+		}
+	}
+	var claims struct {
+		Sub string `json:"sub"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	return claims.Sub
+}
+
+// resolveThreadID normalizes the --session override or, when empty, falls
+// back to a stable hash of the current working directory.
+func resolveThreadID(session string) string {
+	if s := strings.TrimSpace(session); s != "" {
+		return s
+	}
+	return DefaultSession()
+}
+
+// DefaultSession returns the stable default thread id derived from the
+// current working directory. Same directory -> same thread id across
+// invocations, so a user running `klausctl prompt --remote=...` twice
+// from the same repo reuses the same conversation thread.
+func DefaultSession() string {
+	wd, err := os.Getwd()
+	if err != nil || wd == "" {
+		return "default"
+	}
+	sum := sha256.Sum256([]byte(wd))
+	return "cwd-" + hex.EncodeToString(sum[:])[:16]
+}
+
+// joinURL concatenates URL segments, ensuring exactly one slash between
+// adjacent pieces. Segments may already carry their own slashes.
+func joinURL(parts ...string) string {
+	var out strings.Builder
+	for i, p := range parts {
+		if i == 0 {
+			out.WriteString(strings.TrimRight(p, "/"))
+			continue
+		}
+		if !strings.HasPrefix(p, "/") {
+			out.WriteByte('/')
+		}
+		out.WriteString(strings.TrimRight(p, "/"))
+	}
+	return out.String()
+}
+
+// pathEscape percent-encodes an instance name for inclusion in a URL path.
+// Instance names are DNS-label-shaped today, but escape defensively so a
+// future loosening of the rules doesn't break the URL builder.
+func pathEscape(s string) string {
+	return url.PathEscape(s)
+}

--- a/pkg/remote/target_test.go
+++ b/pkg/remote/target_test.go
@@ -1,0 +1,174 @@
+package remote
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeBaseURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"https root", "https://gw.example.com", "https://gw.example.com", false},
+		{"trailing slash", "https://gw.example.com/", "https://gw.example.com", false},
+		{"trailing v1", "https://gw.example.com/v1", "https://gw.example.com", false},
+		{"trailing v1 slash", "https://gw.example.com/v1/", "https://gw.example.com", false},
+		{"with subpath", "https://gw.example.com/klaus", "https://gw.example.com/klaus", false},
+		{"query and fragment dropped", "https://gw.example.com/?x=1#f", "https://gw.example.com", false},
+		{"whitespace trimmed", "  https://gw.example.com  ", "https://gw.example.com", false},
+		{"http allowed", "http://localhost:8080", "http://localhost:8080", false},
+		{"empty", "", "", true},
+		{"no scheme", "gw.example.com", "", true},
+		{"ftp scheme", "ftp://gw.example.com", "", true},
+		{"no host", "https://", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeBaseURL(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %q", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("NormalizeBaseURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTargetURLComposition(t *testing.T) {
+	tgt, err := NewTarget("https://gw.example.com/v1/", "dev-abc", "feature-x", "")
+	if err != nil {
+		t.Fatalf("NewTarget: %v", err)
+	}
+	if got, want := tgt.CompletionsURL(), "https://gw.example.com/v1/dev-abc/chat/completions"; got != want {
+		t.Errorf("CompletionsURL = %q, want %q", got, want)
+	}
+	if got, want := tgt.MCPURL(), "https://gw.example.com/v1/dev-abc/mcp"; got != want {
+		t.Errorf("MCPURL = %q, want %q", got, want)
+	}
+	if got, want := tgt.BaseURL, "https://gw.example.com"; got != want {
+		t.Errorf("BaseURL = %q, want %q (trailing /v1 should have been stripped)", got, want)
+	}
+	if tgt.ThreadID != "feature-x" {
+		t.Errorf("ThreadID = %q, want explicit session %q", tgt.ThreadID, "feature-x")
+	}
+}
+
+func TestTargetURLEscapesInstance(t *testing.T) {
+	tgt, err := NewTarget("https://gw.example.com", "name with space", "s", "")
+	if err != nil {
+		t.Fatalf("NewTarget: %v", err)
+	}
+	if !strings.Contains(tgt.CompletionsURL(), "/v1/name%20with%20space/chat/completions") {
+		t.Errorf("instance not escaped in URL: %s", tgt.CompletionsURL())
+	}
+}
+
+func TestNewTargetRequiresInstance(t *testing.T) {
+	if _, err := NewTarget("https://gw.example.com", "", "", ""); err == nil {
+		t.Fatalf("expected error when instance is empty")
+	}
+}
+
+func TestTargetHeaders(t *testing.T) {
+	tgt := Target{
+		BaseURL:   "https://gw.example.com",
+		Instance:  "dev",
+		ChannelID: "laptop.local",
+		UserID:    "alice",
+		ThreadID:  "thread-xyz",
+	}
+	h := tgt.Headers()
+	if h[ChannelHeader] != ChannelCLI {
+		t.Errorf("expected channel=cli, got %q", h[ChannelHeader])
+	}
+	if h[ChannelIDHeader] != "laptop.local" {
+		t.Errorf("channel-id header missing or wrong: %q", h[ChannelIDHeader])
+	}
+	if h[UserIDHeader] != "alice" {
+		t.Errorf("user-id header missing or wrong: %q", h[UserIDHeader])
+	}
+	if h[ThreadIDHeader] != "thread-xyz" {
+		t.Errorf("thread-id header missing or wrong: %q", h[ThreadIDHeader])
+	}
+}
+
+func TestTargetHeadersOmitsEmptyFields(t *testing.T) {
+	tgt := Target{BaseURL: "https://gw.example.com", Instance: "dev"}
+	h := tgt.Headers()
+	if _, ok := h[ChannelIDHeader]; ok {
+		t.Errorf("channel-id should be omitted when empty: %v", h)
+	}
+	if _, ok := h[UserIDHeader]; ok {
+		t.Errorf("user-id should be omitted when empty: %v", h)
+	}
+	if _, ok := h[ThreadIDHeader]; ok {
+		t.Errorf("thread-id should be omitted when empty: %v", h)
+	}
+	if h[ChannelHeader] != ChannelCLI {
+		t.Errorf("channel header should always be present: %v", h)
+	}
+}
+
+func TestResolveUserIDPrefersJWTSubject(t *testing.T) {
+	// Build an unsigned token whose payload is base64url-encoded JSON
+	// with sub="alice@example.com".
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"alice@example.com"}`))
+	token := "header." + payload + ".sig"
+
+	t.Setenv("USER", "fallback")
+	if got := ResolveUserID(token); got != "alice@example.com" {
+		t.Errorf("ResolveUserID(jwt) = %q, want %q (JWT sub should win over $USER)", got, "alice@example.com")
+	}
+}
+
+func TestResolveUserIDFallsBackToEnv(t *testing.T) {
+	t.Setenv("USER", "bob")
+	if got := ResolveUserID(""); got != "bob" {
+		t.Errorf("ResolveUserID(\"\") = %q, want %q", got, "bob")
+	}
+	t.Setenv("USER", "")
+	t.Setenv("LOGNAME", "logname-user")
+	if got := ResolveUserID(""); got != "logname-user" {
+		t.Errorf("ResolveUserID empty USER = %q, want %q", got, "logname-user")
+	}
+}
+
+func TestResolveUserIDUnknownWhenNothingSet(t *testing.T) {
+	t.Setenv("USER", "")
+	t.Setenv("LOGNAME", "")
+	if got := ResolveUserID(""); got != "unknown" {
+		t.Errorf("ResolveUserID with nothing set = %q, want %q", got, "unknown")
+	}
+}
+
+func TestDefaultSessionStableFromCwd(t *testing.T) {
+	a := DefaultSession()
+	b := DefaultSession()
+	if a != b {
+		t.Errorf("DefaultSession is not stable: %q vs %q", a, b)
+	}
+	if !strings.HasPrefix(a, "cwd-") {
+		t.Errorf("DefaultSession should start with cwd- prefix: %q", a)
+	}
+}
+
+func TestNewTargetUsesExplicitSession(t *testing.T) {
+	tgt, err := NewTarget("https://gw.example.com", "dev", "   my-thread  ", "")
+	if err != nil {
+		t.Fatalf("NewTarget: %v", err)
+	}
+	if tgt.ThreadID != "my-thread" {
+		t.Errorf("ThreadID = %q, want trimmed %q", tgt.ThreadID, "my-thread")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #198.

- Adds `--remote=URL` and `--session=NAME` to `klausctl run`, `prompt`, and `messages` so these commands can target a remote klaus-gateway instead of a local container. Local mode is unchanged byte-for-byte (no auth state consulted, no new headers on the wire).
- Requests target `<remote>/v1/<instance>/chat/completions` and `<remote>/v1/<instance>/mcp` with `X-Klaus-Channel: cli`, `X-Klaus-Channel-ID`, `X-Klaus-User-ID`, and `X-Klaus-Thread-ID` headers. Thread id defaults to a stable hash of the working directory; `--session` overrides it.
- New `klausctl auth login --remote=URL` (plus `logout`/`status`) runs the same OAuth PKCE flow used elsewhere and persists per-host credentials under `~/.config/klausctl/auth/<host>.yaml` (directory `0700`, files `0600`). Cached records store the token endpoint + client id so refresh works without re-discovery.
- Tokens are refreshed proactively (60s leeway before each call) and reactively exactly once on HTTP 401. Failures are surfaced as a `re-run 'klausctl auth login --remote=URL'` hint instead of a cryptic OAuth error.
- Same inputs are exposed on the MCP tools (`klaus_run`, `klaus_prompt`, `klaus_messages`) served by `klausctl serve`.
- `internal/remotesurface` is the single source of truth for the new flags, and `cmd/remote_parity_test.go` extends the PR #196 parity pattern to the three new commands/tools.
- Docs: `docs/remote.md` covers URL shape, headers, auth store, and refresh behaviour; `docs/gatewaybridge.md` and `README.md` cross-ref it.

## Test plan

- [x] `go vet ./...` clean.
- [x] `go test ./... -count=1` green (pre-existing orchestrator tests that depend on `/etc/klaus/sources.yaml` fail only inside the sandbox's read-only rootfs and are unrelated).
- [x] New unit tests cover URL composition, routing headers, JWT-sub resolution, auth store roundtrip + `0600` perms + atomic write, refresh success + relogin on 401/400.
- [x] New integration tests in `cmd/` stand up a fake gateway with `httptest` and assert request path, headers, body, SSE passthrough, and refresh-on-401 retry with persisted rotation.
- [x] Parity test asserts every CLI subcommand (`run`/`prompt`/`messages`) and matching MCP tool expose both `remote` and `session`.
- [ ] CI with `-race` + full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)