### PR TITLE
docs: add docs/musterbridge.md (#200)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# klausctl – agent context
+
+## Repository layout
+
+- `cmd/` -- Cobra command definitions (one file per command group)
+- `pkg/` -- shared library packages
+- `internal/` -- packages not intended for external import
+- `docs/` -- narrative documentation
+
+## Key packages
+
+| Package | Purpose |
+|---------|---------|
+| `pkg/musterbridge` | Local lifecycle manager for the muster aggregator |
+| `pkg/gatewaybridge` | Local lifecycle manager for `klaus-gateway` |
+| `pkg/config` | Instance config loading, path resolution (`Paths` struct) |
+| `pkg/mcpserverstore` | Read/write `mcpservers.yaml` |
+| `pkg/runtime` | Docker/Podman detection and container operations |
+| `internal/tools/muster` | MCP tool registration for the muster bridge |
+| `internal/tools/gateway` | MCP tool registration for the gateway bridge |
+
+## Bridge documentation
+
+- [docs/musterbridge.md](docs/musterbridge.md) -- state files, ownership, MCP tools, troubleshooting
+- [docs/gatewaybridge.md](docs/gatewaybridge.md) -- state files, ownership, MCP tools, troubleshooting
+
+## Conventions
+
+- Bridge packages expose `Start`, `Stop`, `GetStatus`, `EnsureRunning` functions.
+- CLI surface and MCP tool inputs must stay in sync. The gateway bridge enforces
+  this with a parity test in `cmd/gateway_parity_test.go`.
+- State files follow strict ownership: klausctl owns PID/port files; users own
+  config files. klausctl never writes to user-owned files.
+- New tests go in `_test.go` files in the same package as the code under test.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,17 @@ The configuration intentionally mirrors the Helm chart values structure so that 
                   gsoci.azurecr.io/giantswarm/klaus:latest
 ```
 
+## Local bridges
+
+klausctl can manage two local background services so containerized agents
+reach host-side tooling:
+
+- **Muster bridge** (`klausctl muster start|stop|status|restart`) -- aggregates
+  stdio MCP servers behind a single HTTP endpoint. See
+  [docs/musterbridge.md](docs/musterbridge.md).
+- **Gateway bridge** (`klausctl gateway start|stop|status`) -- manages a local
+  `klaus-gateway` process. See [docs/gatewaybridge.md](docs/gatewaybridge.md).
+
 ## Development
 
 ```bash

--- a/docs/musterbridge.md
+++ b/docs/musterbridge.md
@@ -1,0 +1,142 @@
+# Muster bridge
+
+The muster bridge is klausctl's local lifecycle manager for
+[muster](https://github.com/giantswarm/muster), an HTTP aggregator that
+exposes stdio MCP servers behind a single HTTP endpoint. It spawns a `muster
+serve` process, tracks PID/port, health-checks the `/mcp` endpoint, and
+registers the resulting URL in `~/.config/klausctl/mcpservers.yaml` so
+containerized klaus instances can reach it via `host.docker.internal`.
+
+Containerized agents cannot reach stdio MCP servers directly. The muster
+bridge solves this by aggregating the servers you configure in
+`~/.config/klausctl/muster/mcpservers/` and making them available at a
+single HTTP endpoint. Instance configs reference the bridge via
+`mcpServerRefs: [muster]`.
+
+For managing a local `klaus-gateway` process instead, see
+[docs/gatewaybridge.md](gatewaybridge.md).
+
+## CLI
+
+```
+klausctl muster start
+klausctl muster stop
+klausctl muster status
+klausctl muster restart
+```
+
+`restart` is a convenience alias for stop followed by start; it is useful
+after adding or editing files under `muster/mcpservers/`.
+
+## MCP tools
+
+Agents running inside `klausctl serve` see three tools:
+
+- `klaus_muster_start` -- starts the bridge; returns the status JSON.
+- `klaus_muster_stop` -- no arguments.
+- `klaus_muster_status` -- returns the same JSON shape the CLI emits.
+
+Unlike the gateway bridge, `muster start` accepts no flags. All
+configuration lives in `muster/config.yaml` and the `muster/mcpservers/`
+directory.
+
+## Binary resolution
+
+The bridge locates the muster binary via a PATH lookup:
+
+```
+exec.LookPath("muster")
+```
+
+When `muster` is not on `$PATH`, start fails with:
+
+```
+muster binary not found in PATH; install it with: go install github.com/giantswarm/muster@latest
+```
+
+There is no env-var or flag override for the binary path.
+
+## State directory layout
+
+```
+~/.config/klausctl/
+  mcpservers.yaml         # klausctl auto-registers muster on start
+  muster/                 # mixed ownership -- see below
+    config.yaml           # user-owned: aggregator port
+    mcpservers/           # user-owned: one YAML file per MCP server
+      *.yaml
+  muster.pid              # klausctl-owned
+  muster.port             # klausctl-owned
+```
+
+### Ownership boundaries
+
+**klausctl owns**
+
+- `muster.pid`
+- `muster.port`
+
+**The user owns**
+
+- `muster/config.yaml`
+- `muster/mcpservers/*.yaml`
+
+klausctl never writes to user-owned files; the user should never touch
+klausctl-owned files. `muster stop` cleans up the klausctl-owned PID/port
+files and removes the `muster` entry from `mcpservers.yaml` but leaves
+`muster/config.yaml` and `muster/mcpservers/` untouched.
+
+### `muster/config.yaml` schema
+
+All fields are optional. klausctl reads only `aggregator.port`; muster reads
+the full file.
+
+```yaml
+aggregator:
+  port: 8090          # overrides the default muster listen port
+```
+
+### `muster/mcpservers/*.yaml`
+
+Each `.yaml` file in `muster/mcpservers/` describes one MCP server. Muster
+reads these files directly; klausctl only checks that at least one file
+exists before starting the bridge. Refer to the
+[muster documentation](https://github.com/giantswarm/muster) for the
+per-file schema.
+
+## Bootstrap matrix
+
+The bridge has two prerequisites. Start fails fast with a descriptive error
+when either is unmet.
+
+| Condition | Outcome |
+|-----------|---------|
+| `muster` not on `$PATH` | error: binary not found |
+| `muster/mcpservers/` empty or missing | error: no MCP server files configured |
+| Both met, bridge not yet running | start succeeds; PID/port files written |
+| Both met, bridge already running | idempotent; existing process reused |
+
+## Container networking
+
+The bridge listens on the port muster binds to (default `0.0.0.0:8090`).
+Containers reach it at `http://host.docker.internal:<port>/mcp` via the
+`--add-host host.docker.internal:host-gateway` flag that klausctl already
+adds to `docker run` / `podman run`. On Linux, the extra-host flag is
+mandatory; macOS and Windows resolve `host.docker.internal` natively.
+
+## Troubleshooting
+
+**Stale PID file after an ungraceful shutdown.** `muster status` detects a
+stale PID, removes the PID/port files, and reports `not running`. A fresh
+`muster start` brings the bridge back up.
+
+**Start fails because no server files exist.** klausctl refuses to start the
+bridge when `muster/mcpservers/` is empty or absent. Create at least one
+`.yaml` file there before running `muster start`.
+
+**Port collision with an existing process.** Set `aggregator.port` in
+`muster/config.yaml` to a free port and run `muster restart`. The
+`mcpservers.yaml` entry is updated to match.
+
+**New server files not picked up.** `muster restart` reloads
+`muster/mcpservers/` without manual PID/port cleanup.


### PR DESCRIPTION
## Summary

Closes #200.

`docs/gatewaybridge.md` (added with #196) and `docs/remote.md` (added with #199) reference a sibling `docs/musterbridge.md` that never existed. This PR adds it with the same structure.

### Changes

- `docs/musterbridge.md` -- mirrors `docs/gatewaybridge.md`: overview, CLI, MCP tools, binary resolution, state files, auto-registration, container networking, troubleshooting.
- `README.md` -- cross-reference added next to `docs/gatewaybridge.md`.
- `CLAUDE.md` -- agent pointer to `docs/musterbridge.md`.

Docs-only PR; no source code changes.

## Test plan

- [ ] Markdown renders correctly on GitHub.
- [ ] All cross-references resolve (`docs/gatewaybridge.md`, `docs/remote.md`, `pkg/musterbridge`).
- [ ] CI green.

Made with [Cursor](https://cursor.com)