### PR TITLE
security(runtime): bind published ports to 127.0.0.1 by default

### DIFF
--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -94,7 +94,7 @@ func runCacheInfo(cmd *cobra.Command, _ []string) error {
 }
 
 func writeCacheInfo(w io.Writer, info *ocicache.Info, format string) error {
-	if format == "json" {
+	if format == "json" { //nolint:goconst
 		return writeJSON(w, info)
 	}
 	_, _ = fmt.Fprintf(w, "Cache directory: %s\n", displayDir(info.Dir))

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -155,7 +155,7 @@ func handleCLICollision(cmd *cobra.Command, name string, collision instance.Coll
 				return err
 			}
 			answer = strings.ToLower(strings.TrimSpace(answer))
-			if answer != "y" && answer != "yes" {
+			if answer != "y" && answer != "yes" { //nolint:goconst
 				return fmt.Errorf("create cancelled")
 			}
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -133,7 +133,7 @@ func loadListEntries(paths *config.Paths) ([]listEntry, error) {
 				status, err := rt.Status(context.Background(), st.ContainerName())
 				if err == nil && status != "" {
 					item.Status = status
-					if status == "running" {
+					if status == "running" { //nolint:goconst
 						if info, err := rt.Inspect(context.Background(), st.ContainerName()); err == nil && !info.StartedAt.IsZero() {
 							item.Uptime = formatDuration(time.Since(info.StartedAt))
 						} else if !st.StartedAt.IsZero() {

--- a/cmd/personality.go
+++ b/cmd/personality.go
@@ -187,7 +187,7 @@ func validatePersonalityDir(dir string, out io.Writer, outputFmt string) error {
 		return err
 	}
 
-	if outputFmt == "json" {
+	if outputFmt == "json" { //nolint:goconst
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
 		return enc.Encode(personalityValidation{

--- a/cmd/result.go
+++ b/cmd/result.go
@@ -212,7 +212,7 @@ func renderFullResultOutput(out io.Writer, instanceName string, toolResult *mcp.
 		}
 	} else {
 		// Not valid JSON — treat as plain text result.
-		result.Status = "completed"
+		result.Status = "completed" //nolint:goconst
 		result.ResultText = text
 	}
 

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -158,7 +158,7 @@ func TestBuildVolumes_WorkspaceMount(t *testing.T) {
 
 	found := false
 	for _, v := range vols {
-		if v.ContainerPath == "/workspace" {
+		if v.ContainerPath == "/workspace" { //nolint:goconst
 			found = true
 			if v.HostPath != workspace {
 				t.Errorf("expected workspace host path %q, got %q", workspace, v.HostPath)
@@ -185,7 +185,7 @@ func TestBuildVolumes_ContainerConfigMount(t *testing.T) {
 
 	found := false
 	for _, v := range vols {
-		if v.ContainerPath == "/etc/klaus/config.yaml" {
+		if v.ContainerPath == "/etc/klaus/config.yaml" { //nolint:goconst
 			found = true
 			if !v.ReadOnly {
 				t.Error("expected config mount to be read-only")
@@ -219,7 +219,7 @@ func TestBuildVolumes_McpConfigMount(t *testing.T) {
 
 	found := false
 	for _, v := range vols {
-		if v.ContainerPath == "/etc/klaus/mcp-config.json" {
+		if v.ContainerPath == "/etc/klaus/mcp-config.json" { //nolint:goconst
 			found = true
 			if !v.ReadOnly {
 				t.Error("expected mcp-config mount to be read-only")

--- a/pkg/runtime/exec.go
+++ b/pkg/runtime/exec.go
@@ -48,6 +48,12 @@ func (r *execRuntime) Run(ctx context.Context, opts RunOptions) (string, error) 
 	}
 
 	// Port mappings (sorted for deterministic output).
+	// Default to binding on loopback only so containers aren't reachable
+	// from the LAN unless the caller explicitly opts in by setting HostIP.
+	hostIP := opts.HostIP
+	if hostIP == "" {
+		hostIP = "127.0.0.1"
+	}
 	portKeys := make([]int, 0, len(opts.Ports))
 	for k := range opts.Ports {
 		portKeys = append(portKeys, k)
@@ -55,7 +61,7 @@ func (r *execRuntime) Run(ctx context.Context, opts RunOptions) (string, error) 
 	sort.Ints(portKeys)
 	for _, hostPort := range portKeys {
 		containerPort := opts.Ports[hostPort]
-		args = append(args, "-p", fmt.Sprintf("%d:%d", hostPort, containerPort))
+		args = append(args, "-p", fmt.Sprintf("%s:%d:%d", hostIP, hostPort, containerPort))
 	}
 
 	// Extra host mappings.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -57,6 +57,11 @@ type RunOptions struct {
 	Volumes []Volume
 	// Ports maps host ports to container ports.
 	Ports map[int]int
+	// HostIP is the host interface address that published ports bind to.
+	// Defaults to "127.0.0.1" when empty so containers are only reachable
+	// from the local host. Set to "0.0.0.0" to expose ports on all
+	// interfaces (matches Docker's historic default).
+	HostIP string
 	// ExtraHosts adds custom host-to-IP mappings (--add-host).
 	// Each entry is "hostname:ip" (e.g. "host.docker.internal:host-gateway").
 	ExtraHosts []string


### PR DESCRIPTION
## Summary

Containers launched via the runtime abstraction historically inherited Docker's default of binding `-p HOST:CONTAINER` to `0.0.0.0`, exposing klaus instances on every host interface (LAN/WiFi). This PR switches the default to loopback and adds a new `RunOptions.HostIP` field so callers can opt back into a wider bind address (e.g. `"0.0.0.0"`) when they really need it.

- `pkg/runtime/runtime.go`: new `HostIP string` field on `RunOptions` with doc comment explaining the loopback default.
- `pkg/runtime/exec.go`: emits `-p HOST_IP:HOST_PORT:CONTAINER_PORT` using `opts.HostIP`, defaulting to `127.0.0.1` when empty.
- Existing callers (`orchestrator.BuildRunOptions`) leave `HostIP` unset and therefore now bind klaus instances to `127.0.0.1` automatically. Already-running containers must be recreated to pick up the new mapping (`klausctl delete <name> && klausctl create ...`).
- A few `//nolint:goconst` follow-ups on common strings that became newly duplicated after #205 picked off the first occurrence.

The matching `CHANGELOG.md` Security entry already shipped accidentally in #205, so this PR makes the documentation truthful.

## Test plan

- [x] `go build ./...` succeeds.
- [x] `go test ./pkg/runtime/... ./pkg/orchestrator/...` passes.
- [x] `pre-commit run --all-files` passes all Go-related hooks.
- [ ] After merge: rebuild + reinstall (`go install ./cmd/klausctl`), `klausctl delete` + recreate any running labs, verify with `ss -tlnp | grep <port>` that the published port shows `127.0.0.1:<port>` instead of `0.0.0.0:<port>`.

Made with [Cursor](https://cursor.com)