### PR TITLE
fix(tests): isolate tests from host GPG config and container runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Published container ports now bind to `127.0.0.1` by default instead of `0.0.0.0`, so klaus instances are no longer reachable from the LAN unless the caller explicitly opts in via the new `RunOptions.HostIP` field.
 
+### Fixed
+
+- Tests in `pkg/worktree`, `pkg/config`, and `internal/tools/instance` no longer fail on developer machines that have GPG-signed commits enforced globally or that have Docker/Podman installed. Worktree/config helpers explicitly disable `commit.gpgsign`/`tag.gpgsign` in their throwaway repos, and the MCP collision tests stub `PATH` so container-runtime auto-detection cannot pick up a real Docker binary.
+
 ### Changed
 
 - Lint cleanup: address all pre-existing `errcheck`, `gosec`, `goconst`, `staticcheck`, `ineffassign`, and `unused` findings reported by the repo's pre-commit `golangci-lint` configuration. No behavior changes; covers `_, _ =` prefixes for ignored writer return values, tightened default file/dir permissions (0o600/0o750), `// #nosec` justifications for trusted subprocess and file-path call sites, removal of redundant embedded field selectors, lowercased error string, and removal of one unused test helper.

--- a/internal/tools/instance/tools_test.go
+++ b/internal/tools/instance/tools_test.go
@@ -18,6 +18,15 @@ import (
 	"github.com/giantswarm/klausctl/pkg/mcpclient"
 )
 
+// hideContainerRuntimes points PATH at an empty directory so runtime auto
+// detection (which uses exec.LookPath for docker/podman) fails. Use this in
+// tests that assert on the "no runtime available" failure path; otherwise the
+// outcome depends on whether docker/podman happen to be installed on the host.
+func hideContainerRuntimes(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+}
+
 func testServerContext(t *testing.T) *server.ServerContext {
 	t.Helper()
 	configHome := filepath.Join(t.TempDir(), "config-home")
@@ -322,6 +331,7 @@ func TestHandleCreateMCPCollisionStoppedWithoutConfirm(t *testing.T) {
 
 func TestHandleCreateMCPCollisionStoppedWithConfirm(t *testing.T) {
 	sc := testServerContext(t)
+	hideContainerRuntimes(t)
 
 	workspace := filepath.Join(t.TempDir(), "ws")
 	if err := os.MkdirAll(workspace, 0o750); err != nil {
@@ -367,6 +377,7 @@ func TestHandleCreateMCPCollisionStoppedWithConfirm(t *testing.T) {
 
 func TestHandleCreateMCPCollisionSuffixAvoidsCollision(t *testing.T) {
 	sc := testServerContext(t)
+	hideContainerRuntimes(t)
 
 	workspace := filepath.Join(t.TempDir(), "ws")
 	if err := os.MkdirAll(workspace, 0o750); err != nil {

--- a/pkg/config/paths_test.go
+++ b/pkg/config/paths_test.go
@@ -25,7 +25,7 @@ func TestDefaultPaths(t *testing.T) {
 	if got := filepath.Base(paths.InstancesDir); got != "instances" {
 		t.Errorf("InstancesDir base = %q, want %q", got, "instances")
 	}
-	if got := filepath.Base(paths.InstanceDir); got != "default" {
+	if got := filepath.Base(paths.InstanceDir); got != "default" { //nolint:goconst
 		t.Errorf("InstanceDir base = %q, want %q", got, "default")
 	}
 	if !strings.Contains(paths.InstanceFile, filepath.Join("instances", "default")) {

--- a/pkg/config/worktree_integration_test.go
+++ b/pkg/config/worktree_integration_test.go
@@ -31,6 +31,8 @@ func setupGitWorkspace(t *testing.T) (bare, clone string) {
 	gitRun(t, "", "clone", bare, clone)
 	gitRun(t, clone, "config", "user.email", "test@test.com")
 	gitRun(t, clone, "config", "user.name", "Test")
+	gitRun(t, clone, "config", "commit.gpgsign", "false")
+	gitRun(t, clone, "config", "tag.gpgsign", "false")
 	gitRun(t, clone, "checkout", "-b", "main")
 	if err := os.WriteFile(filepath.Join(clone, "README.md"), []byte("hello"), 0o600); err != nil {
 		t.Fatal(err)

--- a/pkg/worktree/worktree_test.go
+++ b/pkg/worktree/worktree_test.go
@@ -22,6 +22,8 @@ func initBareRepo(t *testing.T) string {
 	run(t, "", "git", "clone", bare, clone)
 	run(t, clone, "git", "config", "user.email", "test@test.com")
 	run(t, clone, "git", "config", "user.name", "Test")
+	run(t, clone, "git", "config", "commit.gpgsign", "false")
+	run(t, clone, "git", "config", "tag.gpgsign", "false")
 	run(t, clone, "git", "checkout", "-b", "main")
 	if err := os.WriteFile(filepath.Join(clone, "README.md"), []byte("hello"), 0o600); err != nil {
 		t.Fatal(err)
@@ -40,6 +42,8 @@ func cloneRepo(t *testing.T, bare string) string {
 	run(t, "", "git", "clone", bare, clone)
 	run(t, clone, "git", "config", "user.email", "test@test.com")
 	run(t, clone, "git", "config", "user.name", "Test")
+	run(t, clone, "git", "config", "commit.gpgsign", "false")
+	run(t, clone, "git", "config", "tag.gpgsign", "false")
 	return clone
 }
 
@@ -308,6 +312,8 @@ func TestCreateNoFetch(t *testing.T) {
 	run(t, "", "git", "clone", bare, tmpClone)
 	run(t, tmpClone, "git", "config", "user.email", "test@test.com")
 	run(t, tmpClone, "git", "config", "user.name", "Test")
+	run(t, tmpClone, "git", "config", "commit.gpgsign", "false")
+	run(t, tmpClone, "git", "config", "tag.gpgsign", "false")
 	if err := os.WriteFile(filepath.Join(tmpClone, "new.txt"), []byte("new"), 0o600); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Several existing tests fail on a developer workstation when:

- The user's global git config sets `commit.gpgsign = true` (no key available in the throwaway test repos), or
- Docker/Podman is installed in `PATH` (auto-detected by `runtime.New("")` and used to actually start a real container)

Failures observed on `main` before this PR:

- `pkg/worktree/*` -- `TestIsGitRepo`, `TestDefaultBranch`, `TestCreateAndRemove`, `TestCreateProducesSelfContainedGitDir`, `TestCreateNoFetch`, ...
- `pkg/config/TestGenerateInstanceConfig_*`
- `internal/tools/instance/TestHandleCreateMCPCollisionStoppedWithConfirm` and `TestHandleCreateMCPCollisionSuffixAvoidsCollision` (the latter took ~71 s because it actually pulled and ran a klaus container)

## Changes

- `pkg/worktree/worktree_test.go`, `pkg/config/worktree_integration_test.go`: in the test helpers that `git init` / `git clone` throwaway repos, also set `commit.gpgsign=false` and `tag.gpgsign=false` on the local repo so the developer's global signing policy is ignored.
- `internal/tools/instance/tools_test.go`: introduce `hideContainerRuntimes(t)` that does `t.Setenv("PATH", t.TempDir())`. Apply it to the two MCP collision tests whose assertions depend on `runtime.New` failing because no docker/podman is on `PATH`.
- `pkg/config/paths_test.go`: silence one `goconst` warning that was previously hidden by an unrelated edit.

No production code changes.

## Test plan

- [x] `go test ./...` passes locally on a host that has Docker installed and `commit.gpgsign = true` globally
- [x] `go test ./pkg/worktree/... ./pkg/config/... ./internal/tools/instance/...` passes
- [x] `golangci-lint run ./...` -- 0 issues
- [x] `pre-commit run --all-files` passes
- [ ] CI green

Made with [Cursor](https://cursor.com)