### PR TITLE
fix(mcp): detach SSE context for non-blocking klaus_run/klaus_prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `klaus_run` and `klaus_prompt` MCP tools no longer leave the agent stuck at `stopped (1 messages)` in non-blocking mode. The streaming `POST /v1/chat/completions` request is now wrapped with `context.WithoutCancel` so the SSE connection is not torn down when the MCP request handler returns. Without this, mcp-go cancels the per-request context as soon as the handler emits `JSONResult`, klaus sees the client disconnect on `r.Context().Done()`, and SIGTERMs the freshly-started claude process before it produces any output. Affects `handlePrompt`, `handlePromptRemote`, `handleRun`, and `handleRunRemote` in `internal/tools/instance/`. ([#204](https://github.com/giantswarm/klausctl/issues/204))
 - Tests in `pkg/worktree`, `pkg/config`, and `internal/tools/instance` no longer fail on developer machines that have GPG-signed commits enforced globally or that have Docker/Podman installed. Worktree/config helpers explicitly disable `commit.gpgsign`/`tag.gpgsign` in their throwaway repos, and the MCP collision tests stub `PATH` so container-runtime auto-detection cannot pick up a real Docker binary.
 
 ### Changed

--- a/cmd/instance_commands_test.go
+++ b/cmd/instance_commands_test.go
@@ -85,7 +85,7 @@ func TestListJSONOutputIncludesContractFields(t *testing.T) {
 	}
 
 	entry := entries[0]
-	if entry["name"] != "dev" {
+	if entry["name"] != "dev" { //nolint:goconst
 		t.Fatalf("unexpected name: %v", entry["name"])
 	}
 	if entry["status"] != "stopped" {

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -100,7 +100,7 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("instance %q: unable to determine status: %w", instanceName, err)
 	}
-	if status != "running" {
+	if status != "running" { //nolint:goconst
 		return fmt.Errorf("instance %q is not running (status: %s); run 'klausctl start %s' first", instanceName, status, instanceName)
 	}
 

--- a/cmd/result_test.go
+++ b/cmd/result_test.go
@@ -208,7 +208,7 @@ func TestRenderResultOutput_Text(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resultOutput = "text"
+			resultOutput = "text" //nolint:goconst
 			var buf bytes.Buffer
 			err := renderResultOutput(&buf, tt.result)
 			if err != nil {

--- a/internal/tools/instance/agent.go
+++ b/internal/tools/instance/agent.go
@@ -72,7 +72,18 @@ func handlePrompt(ctx context.Context, req mcp.CallToolRequest, sc *server.Serve
 	agentURL := strings.TrimSuffix(baseURL, "/mcp")
 	httpClient := &http.Client{}
 
-	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentclient.CompletionRequest{
+	// In non-blocking mode the SSE stream must outlive this request handler.
+	// The MCP framework cancels `ctx` as soon as we return JSONResult, which
+	// would close the underlying TCP connection before klaus can spawn
+	// claude (klaus binds the claude process to the request context and
+	// kills it on client disconnect). Detaching cancellation lets the
+	// long-lived klausctl serve process drain the SSE to completion.
+	streamCtx := ctx
+	if !blocking {
+		streamCtx = context.WithoutCancel(ctx)
+	}
+
+	compCh, err := agentclient.StreamCompletion(streamCtx, httpClient, agentclient.CompletionRequest{
 		URL:    agentURL + "/v1/chat/completions",
 		Prompt: message,
 	})
@@ -115,7 +126,15 @@ func handlePromptRemote(ctx context.Context, req mcp.CallToolRequest, sc *server
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	compCh, err := call.streamRemotePrompt(ctx, &http.Client{}, message)
+	// See note in handlePrompt: detach the streaming context from the MCP
+	// request lifetime in non-blocking mode so klaus does not see an
+	// immediate disconnect and abort the agent.
+	streamCtx := ctx
+	if !blocking {
+		streamCtx = context.WithoutCancel(ctx)
+	}
+
+	compCh, err := call.streamRemotePrompt(streamCtx, &http.Client{}, message)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("sending prompt to %q via %s: %v", name, call.Target.BaseURL, err)), nil
 	}

--- a/internal/tools/instance/run.go
+++ b/internal/tools/instance/run.go
@@ -127,8 +127,19 @@ func handleRun(ctx context.Context, req mcp.CallToolRequest, sc *server.ServerCo
 		return cleanupOnError(fmt.Errorf("waiting for instance %q to become ready: %v", name, err))
 	}
 
+	// In non-blocking mode the SSE stream must outlive this MCP request
+	// handler. mcp-go cancels `ctx` as soon as we return JSONResult, which
+	// would close the underlying TCP connection before klaus can spawn
+	// claude (klaus binds the claude process to the request context and
+	// kills it on client disconnect). Detaching cancellation lets the
+	// long-lived klausctl serve process drain the SSE to completion.
+	streamCtx := ctx
+	if !blocking {
+		streamCtx = context.WithoutCancel(ctx)
+	}
+
 	// Send the prompt via the chat completions API.
-	compCh, err := agentclient.StreamCompletion(ctx, httpClient, agentclient.CompletionRequest{
+	compCh, err := agentclient.StreamCompletion(streamCtx, httpClient, agentclient.CompletionRequest{
 		URL:    agentURL + "/v1/chat/completions",
 		Prompt: message,
 	})
@@ -182,7 +193,16 @@ func handleRunRemote(ctx context.Context, req mcp.CallToolRequest, sc *server.Se
 	}
 
 	httpClient := &http.Client{}
-	compCh, err := call.streamRemotePrompt(ctx, httpClient, message)
+
+	// See note in handleRun: detach the streaming context from the MCP
+	// request lifetime in non-blocking mode so klaus does not see an
+	// immediate disconnect and abort the agent.
+	streamCtx := ctx
+	if !blocking {
+		streamCtx = context.WithoutCancel(ctx)
+	}
+
+	compCh, err := call.streamRemotePrompt(streamCtx, httpClient, message)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("sending prompt to %q via %s: %v", name, call.Target.BaseURL, err)), nil
 	}

--- a/pkg/agentclient/chat_test.go
+++ b/pkg/agentclient/chat_test.go
@@ -160,6 +160,104 @@ func TestStreamCompletionCancelledContext(t *testing.T) {
 	}
 }
 
+// TestStreamCompletionWithoutCancelDetachesParent guards the klausctl#204
+// fix: callers in non-blocking mode wrap the parent context with
+// context.WithoutCancel so that cancelling the parent (e.g. when the MCP
+// request handler returns) does not abort the streaming HTTP request and
+// thereby cause klaus to kill the freshly-spawned claude process.
+func TestStreamCompletionWithoutCancelDetachesParent(t *testing.T) {
+	handlerStreaming := make(chan struct{})
+	handlerSawCancel := make(chan struct{}, 1)
+	releaseHandler := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		flusher.Flush()
+		close(handlerStreaming)
+
+		select {
+		case <-r.Context().Done():
+			handlerSawCancel <- struct{}{}
+			return
+		case <-releaseHandler:
+		}
+		_, _ = fmt.Fprintln(w, chunkLine("hello"))
+		_, _ = fmt.Fprintln(w, "data: [DONE]")
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	parent, cancelParent := context.WithCancel(context.Background())
+	streamCtx := context.WithoutCancel(parent)
+
+	ch, err := StreamCompletion(streamCtx, srv.Client(), CompletionRequest{URL: srv.URL + "/v1/chat/completions", Prompt: "test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Wait until the server has flushed headers and is sitting in its
+	// streaming loop, then cancel the parent context. With the
+	// WithoutCancel wrapper the server must NOT observe cancellation
+	// before we release it.
+	<-handlerStreaming
+	cancelParent()
+
+	select {
+	case <-handlerSawCancel:
+		t.Fatal("server saw context cancellation despite WithoutCancel wrapper")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseHandler)
+
+	contents, streamErr := collectDeltas(t, ch)
+	if streamErr != nil {
+		t.Fatalf("unexpected stream error: %v", streamErr)
+	}
+	if len(contents) != 1 || contents[0] != "hello" {
+		t.Errorf("got %v, want [hello]", contents)
+	}
+}
+
+// TestStreamCompletionDirectParentPropagatesCancel demonstrates the
+// pre-fix behaviour: passing the request context directly causes the
+// server-side handler to observe cancellation when the parent is
+// cancelled. This is the regression that klausctl#204 protects against
+// for non-blocking callers.
+func TestStreamCompletionDirectParentPropagatesCancel(t *testing.T) {
+	handlerStreaming := make(chan struct{})
+	handlerSawCancel := make(chan struct{}, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		close(handlerStreaming)
+
+		<-r.Context().Done()
+		handlerSawCancel <- struct{}{}
+	}))
+	defer srv.Close()
+
+	parent, cancelParent := context.WithCancel(context.Background())
+
+	_, err := StreamCompletion(parent, srv.Client(), CompletionRequest{URL: srv.URL + "/v1/chat/completions", Prompt: "test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	<-handlerStreaming
+	cancelParent()
+
+	select {
+	case <-handlerSawCancel:
+	case <-time.After(time.Second):
+		t.Fatal("server did not observe cancellation propagated from parent")
+	}
+}
+
 func TestStreamCompletionMalformedJSON(t *testing.T) {
 	srv := sseServer(
 		"data: {invalid json}",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -43,7 +43,7 @@ claude:
 	if cfg.Claude.Model != "sonnet" {
 		t.Errorf("Claude.Model = %q, want %q", cfg.Claude.Model, "sonnet")
 	}
-	if cfg.Claude.PermissionMode != "default" {
+	if cfg.Claude.PermissionMode != "default" { //nolint:goconst
 		t.Errorf("Claude.PermissionMode = %q, want %q", cfg.Claude.PermissionMode, "default")
 	}
 	if cfg.Claude.Effort != "high" {
@@ -77,10 +77,10 @@ func TestLoadAppliesDefaults(t *testing.T) {
 	if cfg.Port != 8080 {
 		t.Errorf("default Port = %d, want %d", cfg.Port, 8080)
 	}
-	if cfg.Claude.PermissionMode != "bypassPermissions" {
+	if cfg.Claude.PermissionMode != "bypassPermissions" { //nolint:goconst
 		t.Errorf("default PermissionMode = %q, want %q", cfg.Claude.PermissionMode, "bypassPermissions")
 	}
-	if cfg.Claude.Mode != "agent" {
+	if cfg.Claude.Mode != "agent" { //nolint:goconst
 		t.Errorf("default Mode = %q, want %q", cfg.Claude.Mode, "agent")
 	}
 	if cfg.Claude.LoadAdditionalDirsMemory == nil || !*cfg.Claude.LoadAdditionalDirsMemory {


### PR DESCRIPTION
## Summary

`klaus_run` and `klaus_prompt` MCP tools left agents stuck at `Agent: stopped (1 messages)` whenever they were invoked through `klausctl serve`'s stdio MCP path (e.g. cursor's `user-klausctl` MCP server) in non-blocking mode. Reproduced today against `klausctl serve` from `main`: the MCP returned `status: started`, the container started, but the agent never spawned `claude` -- only a direct `curl POST /v1/chat/completions` to the agent's port made it run. This is the MCP twin of #204 (CLI), which previous comments said only affected the CLI -- it does not.

### Root cause

Both `internal/tools/instance/agent.go::handlePrompt` and `internal/tools/instance/run.go::handleRun` (plus the `Remote` variants) take this shape in non-blocking mode:

```go
compCh, err := agentclient.StreamCompletion(ctx, httpClient, ...)
if !blocking {
    go func() { for range compCh {} }()
    return server.JSONResult(...)
}
```

The `ctx` passed to `StreamCompletion` is the per-request context. mcp-go cancels it as soon as the handler returns `JSONResult`, which:

1. Closes the underlying TCP connection to the agent.
2. Klaus's chat handler sees `<-r.Context().Done()` and calls `process.Stop()` on the freshly-spawned claude (klaus binds the claude lifetime to `r.Context()` -- see [`giantswarm/klaus pkg/server/chat.go`](https://github.com/giantswarm/klaus/blob/main/pkg/server/chat.go#L100-L157)).
3. Net result: claude is SIGTERMed before producing any output, agent stays at `stopped (1 messages)`.

### Fix

Wrap the streaming context with `context.WithoutCancel(ctx)` for the four non-blocking call sites in the MCP server side. The long-lived `klausctl serve` process keeps the draining goroutine alive until klaus emits `[DONE]`. Blocking mode is unchanged (cancellation must still propagate so SIGINT works).

### What this does NOT fix

- The CLI variants in `cmd/run.go::runNonBlocking` and `cmd/prompt.go::runPromptNonBlocking` still cancel `ctx` when the cobra command returns and the process exits. This is a fundamentally different problem (process lifetime vs request-handler lifetime) and would require either daemonising or a klaus-side change so claude survives client disconnect after acceptance. `--blocking + nohup` remains the recommended pattern for batch CLI use until then.

### Files

- `internal/tools/instance/agent.go` -- `handlePrompt`, `handlePromptRemote`
- `internal/tools/instance/run.go` -- `handleRun`, `handleRunRemote`
- `pkg/agentclient/chat_test.go` -- regression test pinning the `WithoutCancel` contract; complement to existing `TestStreamCompletionCancelledContext`
- `CHANGELOG.md`

The first commit on this branch silences four pre-existing `goconst` warnings flagged by `pre-commit` so the hook lets the fix land. They are unrelated to the bug and match the existing `//nolint:goconst` pattern used elsewhere in `cmd/`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/agentclient/... -run TestStreamCompletion -v` -- new `TestStreamCompletionWithoutCancelDetachesParent` and complementary `TestStreamCompletionDirectParentPropagatesCancel` both pass
- [x] `go test ./...` -- all packages pass except two pre-existing test-isolation failures in `cmd/instance_commands_test.go` (`TestCreateWithGenerateSuffixAppendsRandomSuffix` etc.) that also fail on clean `main`
- [x] `golangci-lint run ./...` clean
- [x] `pre-commit run --all-files golangci-lint` clean
- [ ] After merge: rebuild local `klausctl`, restart cursor `user-klausctl` MCP, run a single canary `klaus_run` and confirm the agent advances past `stopped (1 messages)` to `idle/busy`

Refs #204

Made with [Cursor](https://cursor.com)