### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@9.0.2
+  architect: giantswarm/architect@9.1.0
 
 workflows:
   test:
@@ -10,11 +10,7 @@ workflows:
           context: architect
           name: go-build
           binary: klausctl
-          # Match what the previous goreleaser setup shipped, minus Windows
-          # (architect's go-build doesn't append .exe). The architect default
-          # is linux-only, which would silently drop Mac binaries from
-          # releases and break every Mac user's install path on next upgrade.
-          architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64"
+          architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
           filters:
             tags:
               only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ### Changed
 
 - Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `klausctl-windows-<arch>.exe`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
 
+### Changed
+
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `klausctl-windows-<arch>.exe`.
 
 ## [0.0.102](https://github.com/giantswarm/klausctl/compare/v0.0.101...v0.0.102) (2026-06-03)
 


### PR DESCRIPTION
## What

- `go-build`: adds `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64` to the `architectures` list.
- `upload-release-assets`: already present; now also uploads the new darwin/windows binaries and their cosign `.bundle` files to the GitHub Release.
- Bumps architect orb to 9.1.0, which names Windows binaries `<binary>-windows-<arch>.exe` and matches them in the cosign and upload globs.

Same pattern as giantswarm/muster#796.