### PR TITLE
feat: default git identity from host and support GPG-signed commits

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -35,6 +35,7 @@ var (
 	createGitAuthor         string
 	createGitCredHelper     string
 	createGitHTTPSInsteadOf bool
+	createGPGSign           bool
 	createYes               bool
 	createForce             bool
 	createGenerateSuffix    bool
@@ -85,6 +86,7 @@ func init() {
 	createCmd.Flags().StringVar(&createGitAuthor, "git-author", "", `git author identity "Name <email>"`)
 	createCmd.Flags().StringVar(&createGitCredHelper, "git-credential-helper", "", "git credential helper (currently only 'gh')")
 	createCmd.Flags().BoolVar(&createGitHTTPSInsteadOf, "git-https-instead-of-ssh", false, "rewrite SSH git URLs to HTTPS via container-local gitconfig")
+	createCmd.Flags().BoolVar(&createGPGSign, "gpg-sign", false, "sign agent commits with the host GPG key via a forwarded gpg-agent socket")
 	createCmd.Flags().BoolVarP(&createYes, "yes", "y", false, "auto-confirm replacement of existing instances")
 	createCmd.Flags().BoolVar(&createForce, "force", false, "allow replacing a running instance (prompts for confirmation unless -y is also set)")
 	createCmd.Flags().BoolVar(&createGenerateSuffix, "generate-suffix", true, "append a random 4-character suffix to the instance name (use --no-generate-suffix to disable)")
@@ -121,6 +123,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		GitAuthor:       createGitAuthor,
 		GitCredHelper:   createGitCredHelper,
 		GitHTTPSInstead: createGitHTTPSInsteadOf,
+		GPGSign:         createGPGSign,
 		Yes:             createYes,
 		Force:           createForce,
 		GenerateSuffix:  createGenerateSuffix,

--- a/cmd/create_shared.go
+++ b/cmd/create_shared.go
@@ -41,6 +41,7 @@ type CLICreateParams struct {
 	GitAuthor       string
 	GitCredHelper   string
 	GitHTTPSInstead bool
+	GPGSign         bool
 	Yes             bool
 	Force           bool
 	GenerateSuffix  bool
@@ -150,6 +151,7 @@ func cliCreateInstance(ctx context.Context, cmd *cobra.Command, params CLICreate
 		GitAuthorEmail:       gitEmail,
 		GitCredentialHelper:  params.GitCredHelper,
 		GitHTTPSInsteadOfSSH: params.GitHTTPSInstead,
+		GitSignCommits:       params.GPGSign,
 		EnvVars:              envVars,
 		EnvForward:           params.EnvForward,
 		SecretEnvVars:        secretEnvVars,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -37,6 +37,7 @@ var (
 	runGitAuthor         string
 	runGitCredHelper     string
 	runGitHTTPSInsteadOf bool
+	runGPGSign           bool
 	runYes               bool
 	runForce             bool
 	runGenerateSuffix    bool
@@ -92,6 +93,7 @@ func init() {
 	runCmd.Flags().StringVar(&runGitAuthor, "git-author", "", `git author identity "Name <email>"`)
 	runCmd.Flags().StringVar(&runGitCredHelper, "git-credential-helper", "", "git credential helper (currently only 'gh')")
 	runCmd.Flags().BoolVar(&runGitHTTPSInsteadOf, "git-https-instead-of-ssh", false, "rewrite SSH git URLs to HTTPS via container-local gitconfig")
+	runCmd.Flags().BoolVar(&runGPGSign, "gpg-sign", false, "sign agent commits with the host GPG key via a forwarded gpg-agent socket")
 	runCmd.Flags().BoolVarP(&runYes, "yes", "y", false, "auto-confirm replacement of existing instances")
 	runCmd.Flags().BoolVar(&runForce, "force", false, "allow replacing a running instance (prompts for confirmation unless -y is also set)")
 	runCmd.Flags().BoolVar(&runGenerateSuffix, "generate-suffix", true, "append a random 4-character suffix to the instance name (use --no-generate-suffix to disable)")
@@ -144,6 +146,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		GitAuthor:       runGitAuthor,
 		GitCredHelper:   runGitCredHelper,
 		GitHTTPSInstead: runGitHTTPSInsteadOf,
+		GPGSign:         runGPGSign,
 		Yes:             runYes,
 		Force:           runForce,
 		GenerateSuffix:  runGenerateSuffix,

--- a/internal/tools/instance/create_shared.go
+++ b/internal/tools/instance/create_shared.go
@@ -38,6 +38,7 @@ type mcpCreateParams struct {
 	gitAuthorEmail string
 	gitCredHelper  string
 	gitHTTPS       bool
+	gpgSign        bool
 	mode           string
 	noIsolate      bool
 	noFetch        bool
@@ -115,6 +116,7 @@ func parseMCPCreateParams(req mcp.CallToolRequest) (*mcpCreateParams, error) {
 		gitAuthorEmail: gitAuthorEmail,
 		gitCredHelper:  req.GetString("gitCredentialHelper", ""),
 		gitHTTPS:       req.GetBool("gitHttpsInsteadOfSsh", false),
+		gpgSign:        req.GetBool("gpgSign", false),
 		mode:           req.GetString("mode", "agent"),
 		noIsolate:      req.GetBool("noIsolate", false),
 		noFetch:        req.GetBool("noFetch", false),
@@ -187,6 +189,7 @@ func mcpCreateInstance(ctx context.Context, params *mcpCreateParams, sc *server.
 		GitAuthorEmail:       params.gitAuthorEmail,
 		GitCredentialHelper:  params.gitCredHelper,
 		GitHTTPSInsteadOfSSH: params.gitHTTPS,
+		GitSignCommits:       params.gpgSign,
 		EnvVars:              params.envVars,
 		EnvForward:           params.envForward,
 		McpServers:           params.mcpServers,

--- a/internal/tools/instance/run.go
+++ b/internal/tools/instance/run.go
@@ -42,6 +42,7 @@ func registerRun(s *mcpserver.MCPServer, sc *server.ServerContext) {
 		mcp.WithString("gitAuthor", mcp.Description("Git author identity as \"Name <email>\"; sets GIT_AUTHOR_NAME/GIT_COMMITTER_NAME and GIT_AUTHOR_EMAIL/GIT_COMMITTER_EMAIL in the container")),
 		mcp.WithString("gitCredentialHelper", mcp.Description("Git credential helper (currently only \"gh\" is supported, which configures git to call \"gh auth git-credential\" for github.com)")),
 		mcp.WithBoolean("gitHttpsInsteadOfSsh", mcp.Description("Rewrite SSH git URLs (git@github.com:...) to HTTPS via container-local gitconfig (default: false)")),
+		mcp.WithBoolean("gpgSign", mcp.Description("Sign agent commits with the host GPG key via a forwarded gpg-agent socket; the private key never enters the container (default: false)")),
 		mcp.WithBoolean("generateSuffix", mcp.Description("Append a random 4-character suffix to the instance name to avoid collisions (default: true)")),
 		mcp.WithBoolean("force", mcp.Description("Allow replacing a running instance; requires confirm: true as well")),
 		mcp.WithBoolean("confirm", mcp.Description("Confirm replacement of an existing instance; required when a name collision is detected")),

--- a/internal/tools/instance/tools.go
+++ b/internal/tools/instance/tools.go
@@ -78,6 +78,7 @@ func registerCreate(s *mcpserver.MCPServer, sc *server.ServerContext) {
 		mcp.WithString("gitAuthor", mcp.Description("Git author identity as \"Name <email>\"; sets GIT_AUTHOR_NAME/GIT_COMMITTER_NAME and GIT_AUTHOR_EMAIL/GIT_COMMITTER_EMAIL in the container")),
 		mcp.WithString("gitCredentialHelper", mcp.Description("Git credential helper (currently only \"gh\" is supported, which configures git to call \"gh auth git-credential\" for github.com)")),
 		mcp.WithBoolean("gitHttpsInsteadOfSsh", mcp.Description("Rewrite SSH git URLs (git@github.com:...) to HTTPS via container-local gitconfig (default: false)")),
+		mcp.WithBoolean("gpgSign", mcp.Description("Sign agent commits with the host GPG key via a forwarded gpg-agent socket; the private key never enters the container (default: false)")),
 		mcp.WithBoolean("generateSuffix", mcp.Description("Append a random 4-character suffix to the instance name to avoid collisions (default: true)")),
 		mcp.WithBoolean("force", mcp.Description("Allow replacing a running instance; requires confirm: true as well")),
 		mcp.WithBoolean("confirm", mcp.Description("Confirm replacement of an existing instance; required when a name collision is detected")),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -215,6 +215,15 @@ type GitConfig struct {
 	// (git@github.com:...) are rewritten to HTTPS without modifying
 	// the workspace .git/config.
 	HTTPSInsteadOfSSH bool `yaml:"httpsInsteadOfSsh,omitempty"`
+	// SignCommits enables GPG-signed commits inside the container. The
+	// host gpg-agent's restricted ("extra") socket is forwarded into the
+	// container and a GNUPGHOME containing only the public key is
+	// prepared, so the private key never leaves the host.
+	SignCommits bool `yaml:"signCommits,omitempty"`
+	// SigningKey is the GPG key id or fingerprint used when SignCommits
+	// is enabled. Resolved at create time from the host git config
+	// (user.signingkey) or the secret key matching AuthorEmail when empty.
+	SigningKey string `yaml:"signingKey,omitempty"`
 }
 
 // validCredentialHelpers lists valid credential helper values.

--- a/pkg/config/generate.go
+++ b/pkg/config/generate.go
@@ -45,6 +45,7 @@ type CreateOptions struct {
 	GitAuthorEmail       string
 	GitCredentialHelper  string
 	GitHTTPSInsteadOfSSH bool
+	GitSignCommits       bool
 
 	// Override fields applied after personality resolution.
 	EnvVars        map[string]string
@@ -200,6 +201,21 @@ func GenerateInstanceConfig(paths *Paths, opts CreateOptions) (*Config, error) {
 
 	applyCreateOverrides(cfg, opts)
 
+	// Default the git identity from the host configuration so the agent
+	// never has to invent one (which used to pollute bind-mounted
+	// workspaces with a bogus local identity). Evaluated from the
+	// workspace directory so per-repository identities win.
+	if cfg.Git.AuthorName == "" && cfg.Git.AuthorEmail == "" {
+		cfg.Git.AuthorName, cfg.Git.AuthorEmail = HostGitIdentity(workDir)
+	}
+	if cfg.Git.SignCommits && cfg.Git.SigningKey == "" {
+		key, err := HostSigningKey(workDir, cfg.Git.AuthorEmail)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Git.SigningKey = key
+	}
+
 	return cfg, cfg.Validate()
 }
 
@@ -257,6 +273,9 @@ func applyCreateOverrides(cfg *Config, opts CreateOptions) {
 	}
 	if opts.GitHTTPSInsteadOfSSH {
 		cfg.Git.HTTPSInsteadOfSSH = true
+	}
+	if opts.GitSignCommits {
+		cfg.Git.SignCommits = true
 	}
 
 	if opts.Mode != "" {

--- a/pkg/config/hostgit.go
+++ b/pkg/config/hostgit.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// HostGitIdentity returns the git identity configured on the host
+// (git config user.name / user.email), evaluated from dir so that
+// per-repository identities take precedence over the global one.
+// Either value may be empty when the host has no identity configured.
+func HostGitIdentity(dir string) (name, email string) {
+	return gitConfigGet(dir, "user.name"), gitConfigGet(dir, "user.email")
+}
+
+// HostSigningKey resolves the GPG signing key to use for commit signing.
+// It prefers the host git configuration (user.signingkey, evaluated from
+// dir) and falls back to the fingerprint of the secret key matching email.
+func HostSigningKey(dir, email string) (string, error) {
+	if key := gitConfigGet(dir, "user.signingkey"); key != "" {
+		return key, nil
+	}
+	if email == "" {
+		return "", fmt.Errorf("cannot resolve GPG signing key: git config user.signingkey is unset and no git author email is configured")
+	}
+	out, err := exec.Command("gpg", "--list-secret-keys", "--with-colons", email).Output() // #nosec G204 -- email comes from the user's own git config
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve GPG signing key: git config user.signingkey is unset and gpg has no secret key for %q", email)
+	}
+	if fpr := firstSecretKeyFingerprint(string(out)); fpr != "" {
+		return fpr, nil
+	}
+	return "", fmt.Errorf("cannot resolve GPG signing key: no secret key fingerprint found for %q", email)
+}
+
+// firstSecretKeyFingerprint extracts the fingerprint of the first secret
+// key from gpg --with-colons output (the "fpr" record following a "sec"
+// record).
+func firstSecretKeyFingerprint(colons string) string {
+	seenSec := false
+	for _, line := range strings.Split(colons, "\n") {
+		fields := strings.Split(line, ":")
+		switch fields[0] {
+		case "sec":
+			seenSec = true
+		case "fpr":
+			if seenSec && len(fields) > 9 && fields[9] != "" {
+				return fields[9]
+			}
+		}
+	}
+	return ""
+}
+
+func gitConfigGet(dir, key string) string {
+	cmd := exec.Command("git", "config", "--get", key) // #nosec G204 -- key is a fixed literal passed by callers in this file
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/pkg/config/hostgit_test.go
+++ b/pkg/config/hostgit_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFirstSecretKeyFingerprint(t *testing.T) {
+	colons := `sec:u:4096:1:C8A8E3F23BAB4599:1468411498::::::scESC:::+:::23::0:
+fpr:::::::::43F38C03302CCD02D29EC068C8A8E3F23BAB4599:
+uid:u::::1468411498::ABCDEF::Test User <test@example.com>::::::::::0:
+ssb:u:4096:1:0123456789ABCDEF:1468411498::::::e:::+:::23:
+fpr:::::::::FEDCBA9876543210FEDCBA9876543210FEDCBA98:
+`
+	got := firstSecretKeyFingerprint(colons)
+	want := "43F38C03302CCD02D29EC068C8A8E3F23BAB4599"
+	if got != want {
+		t.Errorf("firstSecretKeyFingerprint = %q, want %q", got, want)
+	}
+}
+
+func TestFirstSecretKeyFingerprint_NoSecretKey(t *testing.T) {
+	if got := firstSecretKeyFingerprint("pub:u:4096:1:AAAA:1::::::e:\nfpr:::::::::BBBB:\n"); got != "" {
+		t.Errorf("expected empty fingerprint, got %q", got)
+	}
+}
+
+func TestHostGitIdentity_FromGlobalConfig(t *testing.T) {
+	dir := t.TempDir()
+	gitconfig := filepath.Join(dir, "gitconfig")
+	content := "[user]\n\tname = Test User\n\temail = test@example.com\n"
+	if err := os.WriteFile(gitconfig, []byte(content), 0o600); err != nil {
+		t.Fatalf("write gitconfig: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", gitconfig)
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+
+	name, email := HostGitIdentity(dir)
+	if name != "Test User" {
+		t.Errorf("name = %q, want %q", name, "Test User")
+	}
+	if email != "test@example.com" {
+		t.Errorf("email = %q, want %q", email, "test@example.com")
+	}
+}
+
+func TestHostSigningKey_FromGitConfig(t *testing.T) {
+	dir := t.TempDir()
+	gitconfig := filepath.Join(dir, "gitconfig")
+	content := "[user]\n\tsigningkey = CAFEBABE\n"
+	if err := os.WriteFile(gitconfig, []byte(content), 0o600); err != nil {
+		t.Fatalf("write gitconfig: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", gitconfig)
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+
+	key, err := HostSigningKey(dir, "test@example.com")
+	if err != nil {
+		t.Fatalf("HostSigningKey: %v", err)
+	}
+	if key != "CAFEBABE" {
+		t.Errorf("key = %q, want %q", key, "CAFEBABE")
+	}
+}

--- a/pkg/orchestrator/gpg.go
+++ b/pkg/orchestrator/gpg.go
@@ -1,0 +1,107 @@
+package orchestrator
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/giantswarm/klausctl/pkg/config"
+	"github.com/giantswarm/klausctl/pkg/runtime"
+)
+
+// containerGNUPGHome is where the prepared GNUPGHOME is mounted inside the
+// container. GNUPGHOME is pointed here so gpg finds both the public keyring
+// and the forwarded agent socket.
+const containerGNUPGHome = "/etc/klaus/gnupg"
+
+// buildGPGVolumes prepares commit signing for the container when
+// git.signCommits is enabled:
+//
+//   - a minimal GNUPGHOME containing only the exported public key is
+//     rendered on the host and mounted read-write (gpg needs lock files),
+//   - the host gpg-agent's restricted "extra" socket is mounted at
+//     $GNUPGHOME/S.gpg-agent, so private key operations stay on the host
+//     (the restricted socket disallows key export and admin commands).
+//
+// Returns nil volumes when signing is disabled.
+func buildGPGVolumes(cfg *config.Config, paths *config.Paths, env map[string]string) ([]runtime.Volume, error) {
+	if !cfg.Git.SignCommits {
+		return nil, nil
+	}
+	key := cfg.Git.SigningKey
+	if key == "" {
+		return nil, fmt.Errorf("git.signCommits is enabled but git.signingKey is empty; re-create the instance or set git.signingKey in the instance config")
+	}
+
+	socket, err := hostAgentExtraSocket()
+	if err != nil {
+		return nil, err
+	}
+
+	home, err := renderGNUPGHome(paths.RenderedDir, key)
+	if err != nil {
+		return nil, err
+	}
+
+	env["GNUPGHOME"] = containerGNUPGHome
+	return []runtime.Volume{
+		{HostPath: home, ContainerPath: containerGNUPGHome},
+		{HostPath: socket, ContainerPath: containerGNUPGHome + "/S.gpg-agent"},
+	}, nil
+}
+
+// hostAgentExtraSocket ensures the host gpg-agent is running and returns the
+// path of its restricted ("extra") socket.
+func hostAgentExtraSocket() (string, error) {
+	if out, err := exec.Command("gpgconf", "--launch", "gpg-agent").CombinedOutput(); err != nil {
+		return "", fmt.Errorf("launching host gpg-agent: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	out, err := exec.Command("gpgconf", "--list-dir", "agent-extra-socket").Output()
+	if err != nil {
+		return "", fmt.Errorf("locating gpg-agent extra socket: %w", err)
+	}
+	socket := strings.TrimSpace(string(out))
+	if _, err := os.Stat(socket); err != nil {
+		return "", fmt.Errorf("gpg-agent extra socket not available at %s: %w", socket, err)
+	}
+	return socket, nil
+}
+
+// renderGNUPGHome builds a fresh GNUPGHOME under renderedDir containing only
+// the public key for signingKey, exported from the host keyring.
+func renderGNUPGHome(renderedDir, signingKey string) (string, error) {
+	home := filepath.Join(renderedDir, "gnupg")
+	if err := os.RemoveAll(home); err != nil {
+		return "", fmt.Errorf("cleaning rendered GNUPGHOME: %w", err)
+	}
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		return "", fmt.Errorf("creating rendered GNUPGHOME: %w", err)
+	}
+
+	// Force the file-based keyring: a fresh homedir on modern gnupg would
+	// otherwise default to keyboxd, whose socket is unreachable from the
+	// container.
+	if err := os.WriteFile(filepath.Join(home, "common.conf"), []byte{}, 0o600); err != nil {
+		return "", fmt.Errorf("writing common.conf: %w", err)
+	}
+
+	pub, err := exec.Command("gpg", "--export", signingKey).Output() // #nosec G204 -- signingKey comes from the instance config the user controls
+	if err != nil {
+		return "", fmt.Errorf("exporting public key %q from host keyring: %w", signingKey, err)
+	}
+	if len(pub) == 0 {
+		return "", fmt.Errorf("host keyring has no public key for %q", signingKey)
+	}
+
+	pubPath := filepath.Join(home, "pubkey.gpg")
+	if err := os.WriteFile(pubPath, pub, 0o600); err != nil {
+		return "", fmt.Errorf("writing exported public key: %w", err)
+	}
+	if out, err := exec.Command("gpg", "--homedir", home, "--batch", "--no-autostart", "--import", pubPath).CombinedOutput(); err != nil { // #nosec G204 -- home is a klausctl-rendered path
+		return "", fmt.Errorf("importing public key into rendered GNUPGHOME: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	return home, nil
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -282,6 +282,12 @@ func BuildVolumes(cfg *config.Config, paths *config.Paths, env map[string]string
 		vols = append(vols, *gitconfigVol)
 	}
 
+	gpgVols, err := buildGPGVolumes(cfg, paths, env)
+	if err != nil {
+		return nil, err
+	}
+	vols = append(vols, gpgVols...)
+
 	secretVols, err := resolveSecretFiles(cfg, paths)
 	if err != nil {
 		return nil, err
@@ -335,10 +341,10 @@ func setGitEnvVars(env map[string]string, git *config.GitConfig) {
 }
 
 // BuildGitConfig generates a container-local gitconfig file content for
-// credential helper and/or URL rewriting. Returns empty string if no
-// gitconfig is needed.
+// credential helper, URL rewriting, and/or commit signing. Returns empty
+// string if no gitconfig is needed.
 func BuildGitConfig(git *config.GitConfig) string {
-	if !git.HTTPSInsteadOfSSH && git.CredentialHelper == "" {
+	if !git.HTTPSInsteadOfSSH && git.CredentialHelper == "" && !git.SignCommits {
 		return ""
 	}
 
@@ -355,6 +361,13 @@ func BuildGitConfig(git *config.GitConfig) string {
 		b.WriteString("[url \"https://github.com/\"]\n")
 		b.WriteString("\tinsteadOf = git@github.com:\n")
 		b.WriteString("\tinsteadOf = ssh://git@github.com/\n")
+	}
+
+	if git.SignCommits {
+		b.WriteString("[user]\n")
+		b.WriteString("\tsigningkey = " + git.SigningKey + "\n")
+		b.WriteString("[commit]\n")
+		b.WriteString("\tgpgsign = true\n")
 	}
 
 	return b.String()

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -693,6 +693,27 @@ func TestBuildGitConfig_HTTPSInsteadOfSSH(t *testing.T) {
 	}
 }
 
+func TestBuildGitConfig_SignCommits(t *testing.T) {
+	git := &config.GitConfig{
+		SignCommits: true,
+		SigningKey:  "43F38C03302CCD02D29EC068C8A8E3F23BAB4599",
+	}
+	content := BuildGitConfig(git)
+
+	if !strings.Contains(content, "[user]") {
+		t.Error("expected user section")
+	}
+	if !strings.Contains(content, "signingkey = 43F38C03302CCD02D29EC068C8A8E3F23BAB4599") {
+		t.Error("expected signingkey entry")
+	}
+	if !strings.Contains(content, "[commit]") {
+		t.Error("expected commit section")
+	}
+	if !strings.Contains(content, "gpgsign = true") {
+		t.Error("expected gpgsign entry")
+	}
+}
+
 func TestBuildGitConfig_Both(t *testing.T) {
 	git := &config.GitConfig{
 		CredentialHelper:  "gh",


### PR DESCRIPTION
## Summary

- Instances created without `--git-author` now inherit the host git identity, evaluated from the workspace directory so per-repo identities take precedence. This removes the failure mode where agents invented a local `Claude <noreply@anthropic.com>` identity that polluted bind-mounted workspaces and broke host-side commit signing.
- New `--gpg-sign` flag on `create`/`run`, `git.signCommits`/`git.signingKey` instance config, and `gpgSign` param on the `klaus_create`/`klaus_run` MCP tools: klausctl renders a GNUPGHOME containing only the exported public key, forwards the host gpg-agent's restricted *extra* socket into the container, and sets `user.signingkey` + `commit.gpgsign` in the container-local gitconfig. The private key never leaves the host.
- The signing key resolves from `user.signingkey` (workspace-evaluated) with a fallback to the secret key matching the author email.

Closes #270

Requires `gnupg` in toolchain images (giantswarm/klaus-toolchains#58, giantswarm/klaus-toolchains-internal#141); webapp toggle in giantswarm/lab#117.

## Test plan

- [x] Unit tests for gitconfig rendering, fingerprint parsing, and host identity/signing-key resolution.
- [ ] End-to-end: instance with `--gpg-sign` produces a commit that verifies with `git log --show-signature` on the host (will validate before merge).

Note: the local pre-commit golangci-lint hook fails on a clean checkout of main (383 pre-existing goconst findings, repo-wide); new code in this PR is clean under `golangci-lint run -E gosec -E goconst -E govet --new-from-rev=origin/main`.

Made with [Cursor](https://cursor.com)